### PR TITLE
upgrade gradle to the latest version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip


### PR DESCRIPTION
To fix "Could not determine java version from ‘9.0.1’", we need to upgrade gradle.

https://discuss.gradle.org/t/could-not-determine-java-version-from-9-0-1/24457