### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
-## Unreleased - 2017-??-??
+## 1.6.1 - 2018-02-24
 
+* Use SpotBugs 3.1.1
 * Fixed "loud output" [#506](https://github.com/spotbugs/spotbugs/issues/506) by adding an option to show progress and disabling it by default, matching the behaviour of the FindBugs Gradle Plugin
 
 ## 1.6.0 - 2017-10-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
+## Unreleased - 2018-??-??
+
 ## 1.6.1 - 2018-02-24
 
 * Use SpotBugs 3.1.1

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 
-version = "1.6.1-SNAPSHOT"
+version = "1.6.1"
 group = "com.github.spotbugs"
-def spotBugsVersion = '3.1.0'
+def spotBugsVersion = '3.1.1'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 
-version = "1.6.1"
+version = "1.6.2-SNAPSHOT"
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.1'
 sourceCompatibility = 1.8


### PR DESCRIPTION
After we merge this PR, tag `4b185c5` or its rebased commit then Travis CI will release 1.6.1 to Gradle plugin center.