### PR TITLE
Add task mapping for `showProgress` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2018-??-??
 
+* Add `showProgress` option to task mapping.
+
 ## 1.6.1 - 2018-02-25
 
 * Use SpotBugs 3.1.2

--- a/src/main/java/com/github/spotbugs/SpotBugsExtension.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsExtension.java
@@ -31,6 +31,7 @@ import org.gradle.api.resources.TextResource;
  *         includeFilter = file("$rootProject.projectDir/config/spotbugs/includeFilter.xml")
  *         excludeFilter = file("$rootProject.projectDir/config/spotbugs/excludeFilter.xml")
  *         excludeBugsFilter = file("$rootProject.projectDir/config/spotbugs/excludeBugsFilter.xml")
+ *         showProgress = true
  *     }
  *
  * @see SpotBugsPlugin
@@ -47,6 +48,7 @@ public class SpotBugsExtension extends CodeQualityExtension {
     private TextResource excludeFilterConfig;
     private TextResource excludeBugsFilterConfig;
     private Collection<String> extraArgs;
+    private boolean showProgress;
 
     public SpotBugsExtension(Project project) {
         this.project = project;
@@ -280,5 +282,22 @@ public class SpotBugsExtension extends CodeQualityExtension {
      */
     public void setExtraArgs(Collection<String> extraArgs) {
         this.extraArgs = extraArgs;
+    }
+
+    /**
+     * Indicates whether analysis progress should be rendered on standard output. Defaults to false.
+     *
+     * @return {@code true} if analysis progress should be rendered on standard output.
+     */
+    public boolean isShowProgress() {
+        return showProgress;
+    }
+
+    /**
+     * Indicates whether analysis progress should be rendered on standard output.
+     *
+     */
+    public void setShowProgress(boolean showProgress) {
+        this.showProgress = showProgress;
     }
 }

--- a/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -214,6 +214,13 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
                 return extension.getExtraArgs();
             }
         });
+
+        taskMapping.map("showProgress", new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+                return extension.isShowProgress();
+            }
+        });
     }
 
     private void configureReportsConventionMapping(SpotBugsTask task, final String baseName) {


### PR DESCRIPTION
As discussed in https://github.com/spotbugs/spotbugs-gradle-plugin/pull/6 adding the `showProgress` option to task mappings.