### PR TITLE
upgrade spotbugs to 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2018-??-??
 
+* Use SpotBugs 3.1.4
+
 ## 1.6.2 - 2018-05-23
 
 * Use SpotBugs 3.1.3

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply from: "$rootDir/gradle/sonar.gradle"
 
 version = "1.6.3-SNAPSHOT"
 group = "com.github.spotbugs"
-def spotBugsVersion = '3.1.3'
+def spotBugsVersion = '3.1.4'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 


### PR DESCRIPTION
This change upgrade SpotBugs to 3.1.4, CHANGELOG is here:
* https://github.com/spotbugs/spotbugs/releases/tag/3.1.4