### PR TITLE
Update links to sonarcloud badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SpotBugs Gradle Plugin
 
 [![Build Status](https://travis-ci.org/spotbugs/spotbugs-gradle-plugin.svg?branch=master)](https://travis-ci.org/spotbugs/spotbugs-gradle-plugin)
-[![Coverage Status](https://sonarcloud.io/api/badges/measure?key=com.github.spotbugs.gradle&metric=coverage)](https://sonarcloud.io/component_measures?id=com.github.spotbugs.gradle&metric=coverage)
-[![Debt](https://sonarcloud.io/api/badges/measure?key=com.github.spotbugs.gradle&metric=sqale_debt_ratio&template=FLAT)](https://sonarcloud.io/component_measures/domain/Maintainability?id=com.github.spotbugs.gradle)
+[![Coverage Status](https://sonarcloud.io/api/project_badges/measure?project=com.github.spotbugs.gradle&metric=coverage)](https://sonarcloud.io/component_measures?id=com.github.spotbugs.gradle&metric=coverage)
+[![Debt](https://sonarcloud.io/api/project_badges/measure?project=com.github.spotbugs.gradle&metric=sqale_index)](https://sonarcloud.io/component_measures/domain/Maintainability?id=com.github.spotbugs.gradle)
 
 
 ## License


### PR DESCRIPTION
The old badge links were deprecated and removed, see https://about.sonarcloud.io/news/2018/02/05/new-project-badges.html