### PR TITLE
upgrade SpotBugs to 3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2018-??-??
 
+* Use SpotBugs 3.1.6
 * Added support for passing JVM arguments to the JavaExecHandleBuilder when creating a SpotBugsTask.
 
 ## 1.6.2 - 2018-05-23

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply from: "$rootDir/gradle/sonar.gradle"
 
 version = "1.6.3-SNAPSHOT"
 group = "com.github.spotbugs"
-def spotBugsVersion = '3.1.3'
+def spotBugsVersion = '3.1.6'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 


### PR DESCRIPTION
3.1.6 provides [better Java11 supports](https://github.com/spotbugs/spotbugs/blob/3.1.6/CHANGELOG.md) and several bug fixes.