### PR TITLE
Deploy SNAPSHOT version to Sonatype Snapshot repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,9 @@ deploy:
     on:
       tags: true
       jdk: oraclejdk8
+  - provider: script
+    skip_cleanup: true
+    script: ./gradlew uploadArchives -PossrhUsername="$SONATYPE_USERNAME" -PossrhPassword="$SONATYPE_PASSWORD"
+    on:
+      branch: master
+      jdk: oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ apply from: "$rootDir/gradle/checkstyle.gradle"
 apply from: "$rootDir/gradle/jacoco.gradle"
 apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
+apply from: "$rootDir/gradle/deploy.gradle"
 
 version = "1.6.3-SNAPSHOT"
 group = "com.github.spotbugs"

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -1,0 +1,50 @@
+// see https://central.sonatype.org/pages/gradle.html
+
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+uploadArchives {
+  repositories {
+    mavenDeployer {
+      def username = project.hasProperty('ossrhUsername') ? ossrhUsername : "Unknown user"
+      def password = project.hasProperty('ossrhPassword') ? ossrhPassword : "Unknown password"
+
+      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+        authentication(userName: username, password: password)
+      }
+
+      pom.project {
+        packaging 'jar'
+        description 'A Gradle plugin for SpotBugs'
+        url 'https://github.com/spotbugs/spotbugs-gradle-plugin/'
+
+        scm {
+          connection 'scm:git:git@github.com:spotbugs/spotbugs-gradle-plugin.git'
+          developerConnection 'scm:git:git@github.com:spotbugs/spotbugs-gradle-plugin.git'
+          url 'https://github.com/spotbugs/spotbugs-gradle-plugin/'
+        }
+
+        licenses {
+          license {
+            name 'The Apache License, Version 2.0'
+            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related with #41: this PR introduces `deploy` phase to Travis build, to deploy SNAPSHOT version to [the sonatype snapshot repo](https://oss.sonatype.org/content/repositories/snapshots/com/github/spotbugs/spotbugs-gradle-plugin/).