### PR TITLE
Replace usage of internal class ClosureBackedAction

### DIFF
--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -15,7 +15,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.reporting.Reporting;
 import org.gradle.api.reporting.SingleFileReport;
@@ -36,6 +35,7 @@ import org.gradle.api.tasks.VerificationTask;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
+import org.gradle.util.ConfigureUtil;
 
 import com.github.spotbugs.internal.SpotBugsReportsImpl;
 import com.github.spotbugs.internal.SpotBugsReportsInternal;
@@ -133,7 +133,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
      */
     @Override
     public SpotBugsReports reports(Closure closure) {
-        return reports(new ClosureBackedAction<SpotBugsReports>(closure));
+        return reports(ConfigureUtil.configureUsing(closure));
     }
 
     /**


### PR DESCRIPTION
In a commit for Gradle 5.0 the internal class `org.gradle.api.internal.ClosureBackedAction` 
has been moved to org.gradle.util.ClosureBackedAction` 
(see https://github.com/gradle/gradle/commit/b16479080a8864f91d15540d41bc09bdbe2c0af3#diff-bd993f7b907baefcd8fcf66327841ed4).

This commit replaces the usage of `ClosureBackedAction` with `org.gradle.util.ConfigureUtil.configureUsing()`
which is available for a long time.

This fixes an exception when the plugin is used nightly builds of Gradle 5.0:
`java.lang.NoClassDefFoundError: org/gradle/api/internal/ClosureBackedAction`