### PR TITLE
Release 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 ### Changed
 
 * Use SpotBugs 3.1.7 by default
+* Replace usage of internal class ClosureBackedAction [#51](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/51)
 
 ## 1.6.3 - 2018-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
+## Unreleased - 2018-??-??
+
 ## 1.6.4 - 2018-09-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
-## Unreleased - 2018-??-??
+## 1.6.4 - 2018-09-26
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2018-??-??
 
+### Changed
+
+* Use SpotBugs 3.1.7 by default
+
 ## 1.6.3 - 2018-09-08
 
 * Use SpotBugs 3.1.6

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/deploy.gradle"
 
 version = "1.6.4-SNAPSHOT"
 group = "com.github.spotbugs"
-def spotBugsVersion = '3.1.6'
+def spotBugsVersion = '3.1.7'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 
-version = "1.6.4"
+version = "1.6.5-SNAPSHOT"
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.7'
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 
-version = "1.6.4-SNAPSHOT"
+version = "1.6.4"
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.7'
 sourceCompatibility = 1.8


### PR DESCRIPTION
This release uses [SpotBugs 3.1.7](https://github.com/spotbugs/spotbugs/blob/3.1.7/CHANGELOG.md) by default, for better Java 11 support.

It also supports Gradle v5.0 nightly release, that replaces usage of internal API. refs #52