### PR TITLE
Keep track of top-level source set folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2018-??-??
 
+* Keep track of top-level source set folders [#59](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/59)
+
 ## 1.6.4 - 2018-09-26
 
 ### Changed

--- a/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -167,6 +167,8 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
 
         taskMapping.map("extraArgs", extension::getExtraArgs);
         taskMapping.map("showProgress", extension::isShowProgress);
+
+        taskMapping.map("jvmArgs", extension::getJvmArgs);
     }
 
     private void configureReportsConventionMapping(SpotBugsTask task, final String baseName) {
@@ -180,7 +182,7 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, SpotBugsTask task) {
         task.setDescription("Run SpotBugs analysis for " + sourceSet.getName() + " classes");
-        task.setSource(sourceSet.getAllJava());
+        task.setSourceSet(sourceSet);
         ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("classes", (Callable<FileCollection>) () -> {
             /*

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -87,8 +85,6 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
     private Collection<String> extraArgs = new ArrayList<>();
 
     private Collection<String> jvmArgs = new ArrayList<>();
-
-    private Map<String, Object> systemProperties = new HashMap<>();
 
     @Nested
     private final SpotBugsReportsInternal reports;
@@ -268,7 +264,6 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
                 .withExcludeBugsFilter(getExcludeBugsFilter())
                 .withExtraArgs(getExtraArgs())
                 .withJvmArgs(getJvmArgs())
-                .withSystemProperties(getSystemProperties())
                 .configureReports(getReports());
 
         return specBuilder.build();
@@ -297,16 +292,6 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     public SpotBugsTask jvmArgs(String... arguments) {
         jvmArgs.addAll(Arrays.asList(arguments));
-        return this;
-    }
-
-    public SpotBugsTask systemProperty(String name, Object argument) {
-        systemProperties.put(name, argument);
-        return this;
-    }
-
-    public SpotBugsTask systemProperties(Map<String, Object> arguments) {
-        systemProperties.putAll(arguments);
         return this;
     }
 
@@ -637,21 +622,5 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     public void setJvmArgs(Collection<String> jvmArgs) {
         this.jvmArgs = jvmArgs;
-    }
-
-    /**
-     * System properties passed to SpotBugs for additional configuration.
-     * <p>
-     * See the <a href="https://spotbugs.readthedocs.io/en/stable/analysisprops.html">Analysis Properties</a> section for available values.
-     * @return The system properties to pass to the analysis
-     */
-    @Input
-    @Optional
-    public Map<String, Object> getSystemProperties() {
-        return systemProperties;
-    }
-
-    public void setSystemProperties(Map<String, Object> systemProperties) {
-        this.systemProperties = systemProperties;
     }
 }

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpec.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpec.java
@@ -1,11 +1,10 @@
 package com.github.spotbugs.internal.spotbugs;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class SpotBugsSpec implements Serializable {
   private static final long serialVersionUID = 1L;
@@ -13,14 +12,12 @@ public class SpotBugsSpec implements Serializable {
   private String maxHeapSize;
   private boolean debugEnabled;
   private Collection<String> jvmArgs;
-  private final Map<String, Object> systemProperties;
 
-  public SpotBugsSpec(List<String> arguments, String maxHeapSize, boolean debugEnabled, Collection<String> jvmArgs, Map<String, Object> systemProperties) {
+  public SpotBugsSpec(List<String> arguments, String maxHeapSize, boolean debugEnabled, Collection<String> jvmArgs) {
       this.debugEnabled = debugEnabled;
       this.maxHeapSize = maxHeapSize;
       this.arguments = arguments;
       this.jvmArgs = jvmArgs;
-      this.systemProperties = systemProperties;
   }
 
   public List<String> getArguments() {
@@ -37,10 +34,6 @@ public class SpotBugsSpec implements Serializable {
 
   public Collection<String> getJvmArgs() {
       return jvmArgs;
-  }
-
-  public Map<String, Object> getSystemProperties() {
-      return systemProperties;
   }
 
     @Override

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpec.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpec.java
@@ -3,6 +3,7 @@ package com.github.spotbugs.internal.spotbugs;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 
@@ -12,12 +13,14 @@ public class SpotBugsSpec implements Serializable {
   private String maxHeapSize;
   private boolean debugEnabled;
   private Collection<String> jvmArgs;
+  private final Map<String, Object> systemProperties;
 
-  public SpotBugsSpec(List<String> arguments, String maxHeapSize, boolean debugEnabled, Collection<String> jvmArgs) {
+  public SpotBugsSpec(List<String> arguments, String maxHeapSize, boolean debugEnabled, Collection<String> jvmArgs, Map<String, Object> systemProperties) {
       this.debugEnabled = debugEnabled;
       this.maxHeapSize = maxHeapSize;
       this.arguments = arguments;
       this.jvmArgs = jvmArgs;
+      this.systemProperties = systemProperties;
   }
 
   public List<String> getArguments() {
@@ -34,6 +37,10 @@ public class SpotBugsSpec implements Serializable {
 
   public Collection<String> getJvmArgs() {
       return jvmArgs;
+  }
+
+  public Map<String, Object> getSystemProperties() {
+      return systemProperties;
   }
 
     @Override

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
@@ -39,7 +39,6 @@ public class SpotBugsSpecBuilder {
     private File excludeBugsFilter;
     private Collection<String> extraArgs;
     private Collection<String> jvmArgs;
-    private Map<String, Object> systemProperties;
     private boolean showProgress;
     private boolean debugEnabled;
 
@@ -153,11 +152,6 @@ public class SpotBugsSpecBuilder {
         return this;
     }
 
-    public SpotBugsSpecBuilder withSystemProperties(@Nullable Map<String, Object> systemProperties) {
-        this.systemProperties = systemProperties;
-        return this;
-    }
-
     public SpotBugsSpec build() {
         ArrayList<String> args = new ArrayList<>();
         args.add("-pluginList");
@@ -246,8 +240,7 @@ public class SpotBugsSpecBuilder {
         }
 
         return new SpotBugsSpec(args, maxHeapSize, debugEnabled,
-                (this.jvmArgs == null ? Collections.emptyList() : this.jvmArgs),
-                (this.systemProperties == null ? Collections.emptyMap() : this.systemProperties));
+                (this.jvmArgs == null ? Collections.emptyList() : this.jvmArgs));
     }
 
     private boolean has(String str) {

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -38,11 +39,12 @@ public class SpotBugsSpecBuilder {
     private File excludeBugsFilter;
     private Collection<String> extraArgs;
     private Collection<String> jvmArgs;
+    private Map<String, Object> systemProperties;
     private boolean showProgress;
     private boolean debugEnabled;
 
     public SpotBugsSpecBuilder(FileCollection classes) {
-        if(classes == null || classes.isEmpty()){
+        if (classes == null || classes.isEmpty()) {
             throw new InvalidUserDataException("No classes configured for SpotBugs analysis.");
         }
         this.classes = classes;
@@ -136,12 +138,12 @@ public class SpotBugsSpecBuilder {
         return this;
     }
 
-    public SpotBugsSpecBuilder withShowProgress(boolean showProgress){
+    public SpotBugsSpecBuilder withShowProgress(boolean showProgress) {
         this.showProgress = showProgress;
         return this;
     }
 
-    public SpotBugsSpecBuilder withDebugging(boolean debugEnabled){
+    public SpotBugsSpecBuilder withDebugging(boolean debugEnabled) {
         this.debugEnabled = debugEnabled;
         return this;
     }
@@ -151,10 +153,15 @@ public class SpotBugsSpecBuilder {
         return this;
     }
 
+    public SpotBugsSpecBuilder withSystemProperties(@Nullable Map<String, Object> systemProperties) {
+        this.systemProperties = systemProperties;
+        return this;
+    }
+
     public SpotBugsSpec build() {
         ArrayList<String> args = new ArrayList<>();
         args.add("-pluginList");
-        args.add(pluginsList==null ? "" : pluginsList.getAsPath());
+        args.add(pluginsList == null ? "" : pluginsList.getAsPath());
         args.add("-sortByClass");
         args.add("-timestampNow");
 
@@ -238,7 +245,9 @@ public class SpotBugsSpecBuilder {
             args.add(classFile.getAbsolutePath());
         }
 
-        return new SpotBugsSpec(args, maxHeapSize, debugEnabled, (Collection)(this.jvmArgs == null ? Collections.emptyList() : this.jvmArgs));
+        return new SpotBugsSpec(args, maxHeapSize, debugEnabled,
+                (this.jvmArgs == null ? Collections.emptyList() : this.jvmArgs),
+                (this.systemProperties == null ? Collections.emptyMap() : this.systemProperties));
     }
 
     private boolean has(String str) {

--- a/src/test/java/com/github/spotbugs/SourceAnalysisProperty.java
+++ b/src/test/java/com/github/spotbugs/SourceAnalysisProperty.java
@@ -1,0 +1,33 @@
+package com.github.spotbugs;
+
+/**
+ * Used by {@link SourceAnalysisPropertyTest}
+ * as an example of code with a "SwitchFallthrough" deficiency,
+ * which should be disabled through a SpotBugs analysis property.
+ */
+public class SourceAnalysisProperty {
+
+    static int method(String someString) {
+        int result = 5;
+
+        switch (someString) {
+            case "Hello":
+                result = 10;
+                // fall through
+
+            case "Hello, World!":
+                result += 4;
+                // fall through
+
+            default:
+                result += 6;
+                break;
+        }
+
+        return result;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("result = " + method("Hello, World!"));
+    }
+}

--- a/src/test/java/com/github/spotbugs/SourceAnalysisPropertyTest.java
+++ b/src/test/java/com/github/spotbugs/SourceAnalysisPropertyTest.java
@@ -1,0 +1,77 @@
+package com.github.spotbugs;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class SourceAnalysisPropertyTest {
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void createProject() throws IOException {
+        String buildScript =
+                "plugins {\n" +
+                        "  id 'java'\n" +
+                        "  id 'com.github.spotbugs'\n" +
+                        "}\n" +
+                        "version = 1.0\n" +
+                        "repositories {\n" +
+                        "  mavenCentral()\n" +
+                        "  mavenLocal()\n" +
+                        "}\n" +
+                        "sourceSets {\n" +
+                        "  main {\n" +
+                        "    java.srcDirs = ['src/main/java']\n" +
+                        "  }\n" +
+                        "}\n" +
+                        "tasks.withType(com.github.spotbugs.SpotBugsTask) {\n" +
+                        "  jvmArgs = ['-Dfindbugs.sf.comment=true']\n" +
+                        "}\n";
+
+        File buildFile = folder.newFile("build.gradle");
+        Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+
+        File sourceDir = folder.newFolder("src", "main", "java", "com", "github", "spotbugs");
+        File destinationFile = new File(sourceDir, "SourceAnalysisProperty.java");
+        File sourceFile = new File("src/test/java/com/github/spotbugs/SourceAnalysisProperty.java");
+        Files.copy(sourceFile.toPath(), destinationFile.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+    @Test
+    public void testNotReportingSwitchFallthroughWhenSourceAnalysisPropertySet() {
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(folder.getRoot())
+                .withDebug(true)
+                .withArguments(Arrays.asList("compileJava", "spotbugsMain"))
+                .withPluginClasspath().build();
+        Optional<BuildTask> spotbugsTest = findTask(result, ":spotbugsMain");
+        assertTrue(spotbugsTest.isPresent());
+        assertThat(spotbugsTest.get().getOutcome(), is(TaskOutcome.SUCCESS));
+    }
+
+    private Optional<BuildTask> findTask(BuildResult result, String taskName) {
+        return result.getTasks().stream()
+                .filter(task -> task.getPath().equals(taskName))
+                .findAny();
+    }
+}


### PR DESCRIPTION
SpotBugs’ source analysis requires a handle to the top-level source set
folder, or else the SourceFileFinder cannot locate attached sources
of a task. This is especially annoying when some checks require insight
into the source code (e.g. the SwitchFallthrough check, which looks
at comments inside a switch statement). Since SpotBugs tasks are essentially
Gradle SourceTasks, they use a FileTree internally, which only keeps
handles to the leaf files automatically, and doesn’t hold onto the original
directory:

```groovy
new File("src/main/java/com/example/MyFile.java").withWriter {
  it.write("package com.example;\nclass MyFile {}"
}

def fileTree = project.fileTree("src/main/java")
for (file in fileTree.files) {
  // This will not print "/.../src/main/java", but "/.../src/main/java/com/example/MyFile.java" directly.
  println file.absolutePath
}
```

This commit expands the previous behavior with the ability to obtain
the source set folder, and obtains a combined FileCollection to give
to SpotBugs through the new SpotBugsTask#getAllSource() method.

This resolves inquiries like https://github.com/spotbugs/spotbugs-gradle-plugin/issues/16, which are now supported through `jvmArgs` on either the `SpotBugsExtension` or its tasks:

```groovy
tasks.withType(com.github.spotbugs.SpotBugsTask) {
  jvmArgs = ['-Dfindbugs.sf.comment=true']
}
```