### PR TITLE
Narrow the scope of spotbugs dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile "com.github.spotbugs:spotbugs:${spotBugsVersion}"
+    compileOnly "com.github.spotbugs:spotbugs:${spotBugsVersion}"
 
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'//, 'org.spockframework:spock-core:1.0-groovy-2.4'


### PR DESCRIPTION
Fixes #63 

This helps reduce the size of the buildscript classpath of consuming projects.