### PR TITLE
Test with Gradle 5.0-milestone-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - GRADLE_VERSION=default
     - GRADLE_VERSION=4.10.2
-    - GRADLE_VERSION=5.0-20180920000033+0000
+    - GRADLE_VERSION=5.0-milestone-1
   global:
     - SONAR_HOST_URL="https://sonarcloud.io"
 


### PR DESCRIPTION
Replaces snapshot/nightly Gradle build with a more stable milestone release.