### PR TITLE
Use runtime classpath instead of compile classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased
 
+### Changed
+
+* Keep track of top-level source set folders [#59](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/59)
+
+### Fixed
+
+* Analyze runtime classpath instead of compile classpath. [#62](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/62)
+
 ## 1.6.6 - 2018-12-08
 
 ## Fixed
@@ -17,8 +25,6 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 ### Changed
 
 * Replace usage of internal Gradle APIs with supported [Worker API](https://guides.gradle.org/using-the-worker-api/). [#58](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/58)
-
-* Keep track of top-level source set folders [#59](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/59)
 
 ## 1.6.4 - 2018-09-26
 

--- a/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -201,6 +201,6 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
                     .forEach(tree -> tree.builtBy(sourceSet.getClassesTaskName()));
             return presentClassDirs;
         });
-        taskMapping.map("classpath", sourceSet::getCompileClasspath);
+        taskMapping.map("classpath", sourceSet::getRuntimeClasspath);
     }
 }


### PR DESCRIPTION
Same with #67 but rebased to the latest `master` branch.
It also fixes the wrong CHANGELOG entry introduced by #59.