### PR TITLE
Release 1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
-## Unreleased
+## 1.6.8 - 2018-12-21
+
+### Changed
 
 * Use SpotBugs 3.1.10 by default
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased
 
+* Use SpotBugs 3.1.10 by default
+
 ## 1.6.7 - 2018-12-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
+## Unreleased
+
 ## 1.6.8 - 2018-12-21
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/deploy.gradle"
 
 version = '1.6.8-SNAPSHOT'
 group = "com.github.spotbugs"
-def spotBugsVersion = '3.1.9'
+def spotBugsVersion = '3.1.10'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 
-version = '1.6.8-SNAPSHOT'
+version = '1.6.8'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.10'
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 
-version = '1.6.8'
+version = '1.6.9-SNAPSHOT'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.10'
 sourceCompatibility = 1.8


### PR DESCRIPTION
To solve #81, it is [necessary to deploy newer version](https://discuss.gradle.org/t/plugin-cannot-be-published-due-to-exists-already-error/29911/2) so this PR is going to release new version 1.6.8.

It also bump up SpotBugs version to the latest one.