### PR TITLE
Fix warning reported by :validateTaskProperties task

### DIFF
--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -324,7 +324,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
         return super.getSource();
     }
 
-    @Input
+    @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     FileCollection getAllSource() {
         return getProject().files(sourceDirs).plus(getSource());


### PR DESCRIPTION
When we build this project, `:validateTaskProperties` task reports one warning:

```
> Task :validateTaskProperties
Task property validation finished with warnings:
  - Warning: Task type 'com.github.spotbugs.SpotBugsTask': property 'allSource' has @Input annotation used on property of type org.gradle.api.file.FileCollection.
```

This change will fix this warning. I'm not sure we need to update CHANGELOG or not...