### PR TITLE
Extract gradle file for test

### DIFF
--- a/src/test/java/com/github/spotbugs/Issue423Test.java
+++ b/src/test/java/com/github/spotbugs/Issue423Test.java
@@ -23,10 +23,9 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import org.gradle.testkit.runner.BuildResult;
@@ -42,27 +41,12 @@ import org.junit.rules.TemporaryFolder;
  */
 public class Issue423Test {
     @Rule
-    public TemporaryFolder folder= new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void createProject() throws IOException {
-      String buildScript = "plugins {\n" +
-        "  id 'java'\n" +
-        "  id 'com.github.spotbugs'\n" +
-        "}\n" +
-        "version = 1.0\n" +
-        "repositories {\n" +
-        "  mavenCentral()\n" +
-        "  mavenLocal()\n" +
-        "}\n" +
-        "task spotbugs(type: com.github.spotbugs.SpotBugsTask) {\n" +
-        "  reports {\n" +
-        "    xml.enabled true\n" +
-        "    xml.destination ((java.io.File) null)\n" +
-        "  }\n" +
-        "}";
-      File buildFile = folder.newFile("build.gradle");
-      Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+      Files.copy(Paths.get("src/test/resources/Issue423.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+              StandardCopyOption.COPY_ATTRIBUTES);
 
       File sourceDir = folder.newFolder("src", "main", "java");
       File to = new File(sourceDir, "Foo.java");

--- a/src/test/java/com/github/spotbugs/Issue440Test.java
+++ b/src/test/java/com/github/spotbugs/Issue440Test.java
@@ -23,10 +23,9 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import org.gradle.testkit.runner.BuildResult;
@@ -39,21 +38,12 @@ import org.junit.rules.TemporaryFolder;
 
 public class Issue440Test {
     @Rule
-    public TemporaryFolder folder= new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void createProject() throws IOException {
-      String buildScript = "plugins {\n" +
-        "  id 'java'\n" +
-        "  id 'com.github.spotbugs'\n" +
-        "}\n" +
-        "version = 1.0\n" +
-        "repositories {\n" +
-        "  mavenCentral()\n" +
-        "  mavenLocal()\n" +
-        "}";
-      File buildFile = folder.newFile("build.gradle");
-      Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+      Files.copy(Paths.get("src/test/resources/Issue440.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+          StandardCopyOption.COPY_ATTRIBUTES);
 
       File sourceDir = folder.newFolder("src", "main", "java");
       File to = new File(sourceDir, "Foo.java");

--- a/src/test/java/com/github/spotbugs/Issue54Test.java
+++ b/src/test/java/com/github/spotbugs/Issue54Test.java
@@ -24,10 +24,9 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import org.gradle.testkit.runner.BuildResult;
@@ -47,21 +46,8 @@ public class Issue54Test {
 
     @Before
     public void createProject() throws IOException {
-      String buildScript = "plugins {\n" +
-        "  id 'java'\n" +
-        "  id 'com.github.spotbugs'\n" +
-        "}\n" +
-        "version = 1.0\n" +
-        "repositories {\n" +
-        "  mavenCentral()\n" +
-        "}\n" +
-        "spotbugsMain {\n" +
-        "  classes = classes.filter {\n" +
-        "    !it.path.contains('com/')" +
-        "  }\n" +
-        "}";
-      File buildFile = folder.newFile("build.gradle");
-      Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+      Files.copy(Paths.get("src/test/resources/Issue54.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+          StandardCopyOption.COPY_ATTRIBUTES);
 
       File sourceDir = folder.newFolder("src", "main", "java");
       File to = new File(sourceDir, "Foo.java");

--- a/src/test/java/com/github/spotbugs/KotlinBuildScriptTest.java
+++ b/src/test/java/com/github/spotbugs/KotlinBuildScriptTest.java
@@ -1,5 +1,17 @@
 package com.github.spotbugs;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Optional;
+
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
@@ -10,19 +22,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
-import java.util.Optional;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-
 public class KotlinBuildScriptTest {
 
     @Rule
@@ -32,18 +31,8 @@ public class KotlinBuildScriptTest {
 
     @Before
     public void createKotlinDslProject() throws IOException {
-        String buildScript = "plugins {\n" +
-                "  java\n" +
-                "  id(\"com.github.spotbugs\")\n" +
-                "}\n" +
-                "version = 1.0\n" +
-                "repositories {\n" +
-                "  mavenCentral()\n" +
-                "  mavenLocal()\n" +
-                "}\n" +
-                "if(project.hasProperty(\"ignoreFailures\")) { spotbugs.setIgnoreFailures(true) }";
-        File buildFile = folder.newFile("build.gradle.kts");
-        Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+        Files.copy(Paths.get("src/test/resources/KotlinBuildScript.gradle.kts"), folder.getRoot().toPath().resolve("build.gradle.kts"),
+                StandardCopyOption.COPY_ATTRIBUTES);
 
         sourceDir = folder.newFolder("src", "main", "java");
         File to = new File(sourceDir, "Foo.java");

--- a/src/test/java/com/github/spotbugs/MultipleBuildOutputSourceDirsTest.java
+++ b/src/test/java/com/github/spotbugs/MultipleBuildOutputSourceDirsTest.java
@@ -1,11 +1,13 @@
 package com.github.spotbugs;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import org.gradle.internal.impldep.org.apache.commons.io.FileUtils;
@@ -17,9 +19,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
 /**
  * Test's behaviour of the spotbugs plugin when operating with multiple code languages.
  * <p>
@@ -30,7 +29,7 @@ import static org.junit.Assert.assertThat;
 public class MultipleBuildOutputSourceDirsTest {
 
     @Rule
-    public TemporaryFolder folder= new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void cleanUpProjectFolder() {
@@ -93,53 +92,18 @@ public class MultipleBuildOutputSourceDirsTest {
     // =========================== Helper methods =====================================================================
 
     private void createProjectScala() throws IOException {
-      String buildScript = "plugins {\n"
-        + "    id 'java'\n"
-        + "    id 'scala'\n"
-        + "    id 'com.github.spotbugs' version '1.6.1'\n"
-        + "}\n"
-        + "version = 1.0\n"
-        + "repositories {\n"
-        + "    mavenCentral()\n"
-        + "    mavenLocal()\n"
-        + "}\n"
-
-        + "apply plugin: 'java'\n"
-        + "apply plugin: 'scala'\n"
-
-        + "sourceSets.main.scala.srcDirs = ['src/main/java', 'src/main/scala']\n"
-        + "sourceSets.main.java.srcDirs = []\n"
-
-        + "ext.scalaFullVersion = '2.10.3'\n"
-        + "dependencies {\n"
-            + "compile 'org.scala-lang:scala-library:2.10.7'\n"
-        + "}\n";
-      File buildFile = folder.newFile("build.gradle");
-      Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+      Files.copy(Paths.get("src/test/resources/MultipleBuildOutputSourceDirsScala.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+              StandardCopyOption.COPY_ATTRIBUTES);
 
       File javaSourceDir = folder.newFolder("src", "main", "java");
-      File scalaSourceDir = folder.newFolder("src", "main", "scala");
       File to = new File(javaSourceDir, "Foo.java");
       File from = new File("src/test/java/com/github/spotbugs/Foo.java");
       Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
     }
 
     private void createProjectGroovy() throws IOException {
-        String buildScript = "plugins {\n" +
-                "  id 'java'\n" +
-                "  id 'groovy'\n" +
-                "  id 'com.github.spotbugs' version '1.6.1'\n" +
-                "}\n" +
-                "version = 1.0\n" +
-                "repositories {\n" +
-                "  mavenCentral()\n" +
-                "  mavenLocal()\n" +
-                "}\n" +
-                "dependencies {\n" +
-                "    compile 'org.codehaus.groovy:groovy-all:2.4.14'\n" +
-                "}\n";
-        File buildFile = folder.newFile("build.gradle");
-        Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+        Files.copy(Paths.get("src/test/resources/MultipleBuildOutputSourceDirsGroovy.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+                StandardCopyOption.COPY_ATTRIBUTES);
 
         File sourceDir = folder.newFolder("src", "main", "groovy");
         File to = new File(sourceDir, "Bar.groovy");
@@ -148,24 +112,10 @@ public class MultipleBuildOutputSourceDirsTest {
     }
 
     private void createProjectGroovyTest() throws IOException {
-        String buildScript = "plugins {\n" +
-                "  id 'java'\n" +
-                "  id 'groovy'\n" +
-                "  id 'com.github.spotbugs' version '1.6.1'\n" +
-                "}\n" +
-                "version = 1.0\n" +
-                "repositories {\n" +
-                "  mavenCentral()\n" +
-                "  mavenLocal()\n" +
-                "}\n" +
-                "dependencies {\n" +
-                "    compile 'org.codehaus.groovy:groovy-all:2.4.14'\n" +
-                "}\n";
-        File buildFile = folder.newFile("build.gradle");
-        Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+        Files.copy(Paths.get("src/test/resources/MultipleBuildOutputSourceDirsGroovy.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+                StandardCopyOption.COPY_ATTRIBUTES);
 
         File sourceDirJava = folder.newFolder("src", "main", "java");
-        File sourceDirGroovy = folder.newFolder("src", "main", "groovy");
         File sourceDirGroovyTest = folder.newFolder("src", "test", "groovy");
         File to = new File(sourceDirJava, "Foo.java");
         File from = new File("src/test/java/com/github/spotbugs/Foo.java");

--- a/src/test/java/com/github/spotbugs/MultipleClassDirsTest.java
+++ b/src/test/java/com/github/spotbugs/MultipleClassDirsTest.java
@@ -23,10 +23,9 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import org.gradle.testkit.runner.BuildResult;
@@ -39,22 +38,12 @@ import org.junit.rules.TemporaryFolder;
 
 public class MultipleClassDirsTest {
     @Rule
-    public TemporaryFolder folder= new TemporaryFolder();
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void createProject() throws IOException {
-      String buildScript = "plugins {\n" +
-        "  id 'java'\n" +
-        "  id 'com.github.spotbugs'\n" +
-        "}\n" +
-        "version = 1.0\n" +
-        "repositories {\n" +
-        "  mavenCentral()\n" +
-        "  mavenLocal()\n" +
-        "}\n" +
-        "sourceSets.main.output.addClassesDir { -> file('build/classes/java/second') }\n";
-      File buildFile = folder.newFile("build.gradle");
-      Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+      Files.copy(Paths.get("src/test/resources/MultipleClassDirs.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+              StandardCopyOption.COPY_ATTRIBUTES);
 
       File sourceDir = folder.newFolder("src", "main", "java");
       File to = new File(sourceDir, "Foo.java");

--- a/src/test/java/com/github/spotbugs/SourceAnalysisPropertyTest.java
+++ b/src/test/java/com/github/spotbugs/SourceAnalysisPropertyTest.java
@@ -1,11 +1,14 @@
 package com.github.spotbugs;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -18,10 +21,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 public class SourceAnalysisPropertyTest {
 
     @Rule
@@ -29,27 +28,8 @@ public class SourceAnalysisPropertyTest {
 
     @Before
     public void createProject() throws IOException {
-        String buildScript =
-                "plugins {\n" +
-                        "  id 'java'\n" +
-                        "  id 'com.github.spotbugs'\n" +
-                        "}\n" +
-                        "version = 1.0\n" +
-                        "repositories {\n" +
-                        "  mavenCentral()\n" +
-                        "  mavenLocal()\n" +
-                        "}\n" +
-                        "sourceSets {\n" +
-                        "  main {\n" +
-                        "    java.srcDirs = ['src/main/java']\n" +
-                        "  }\n" +
-                        "}\n" +
-                        "tasks.withType(com.github.spotbugs.SpotBugsTask) {\n" +
-                        "  jvmArgs = ['-Dfindbugs.sf.comment=true']\n" +
-                        "}\n";
-
-        File buildFile = folder.newFile("build.gradle");
-        Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+        Files.copy(Paths.get("src/test/resources/SourceAnalysisProperty.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+                StandardCopyOption.COPY_ATTRIBUTES);
 
         File sourceDir = folder.newFolder("src", "main", "java", "com", "github", "spotbugs");
         File destinationFile = new File(sourceDir, "SourceAnalysisProperty.java");

--- a/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
+++ b/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
@@ -5,10 +5,9 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -25,24 +24,14 @@ import org.junit.rules.TemporaryFolder;
 
 public class SpotBugsPluginTest extends Assert{
   @Rule
-  public TemporaryFolder folder= new TemporaryFolder();
+  public TemporaryFolder folder = new TemporaryFolder();
 
   private File sourceDir;
 
   @Before
   public void createProject() throws IOException {
-    String buildScript = "plugins {\n" +
-      "  id 'java'\n" +
-      "  id 'com.github.spotbugs'\n" +
-      "}\n" +
-      "version = 1.0\n" +
-      "repositories {\n" +
-      "  mavenCentral()\n" +
-      "  mavenLocal()\n" +
-      "}\n" +
-      "if(project.hasProperty('ignoreFailures')) { spotbugs.ignoreFailures = true }";
-    File buildFile = folder.newFile("build.gradle");
-    Files.write(buildFile.toPath(), buildScript.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+    Files.copy(Paths.get("src/test/resources/SpotBugsPlugin.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+            StandardCopyOption.COPY_ATTRIBUTES);
 
     sourceDir = folder.newFolder("src", "main", "java");
     File to = new File(sourceDir, "Foo.java");

--- a/src/test/resources/Issue423.gradle
+++ b/src/test/resources/Issue423.gradle
@@ -1,0 +1,14 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+task spotbugs(type: com.github.spotbugs.SpotBugsTask) {
+  reports {
+    xml.enabled true
+    xml.destination ((java.io.File) null)
+  }
+}

--- a/src/test/resources/Issue440.gradle
+++ b/src/test/resources/Issue440.gradle
@@ -1,0 +1,8 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}

--- a/src/test/resources/Issue54.gradle
+++ b/src/test/resources/Issue54.gradle
@@ -1,0 +1,13 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+spotbugsMain {
+  classes = classes.filter {
+    !it.path.contains('com/')
+  }
+}

--- a/src/test/resources/KotlinBuildScript.gradle.kts
+++ b/src/test/resources/KotlinBuildScript.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+  java
+  id("com.github.spotbugs")
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+if (project.hasProperty("ignoreFailures")) {
+  spotbugs.setIgnoreFailures(true)
+}

--- a/src/test/resources/MultipleBuildOutputSourceDirsGroovy.gradle
+++ b/src/test/resources/MultipleBuildOutputSourceDirsGroovy.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'java'
+    id 'groovy'
+    id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+    mavenCentral()
+}
+dependencies {
+    compile 'org.codehaus.groovy:groovy-all:2.4.14'
+}

--- a/src/test/resources/MultipleBuildOutputSourceDirsScala.gradle
+++ b/src/test/resources/MultipleBuildOutputSourceDirsScala.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+    id 'scala'
+    id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+    mavenCentral()
+}
+
+apply plugin: 'java'
+apply plugin: 'scala'
+
+sourceSets.main.scala.srcDirs = ['src/main/java', 'src/main/scala']
+sourceSets.main.java.srcDirs = []
+
+ext.scalaFullVersion = '2.10.3'
+dependencies {
+    compile 'org.scala-lang:scala-library:2.10.7'
+}

--- a/src/test/resources/MultipleClassDirs.gradle
+++ b/src/test/resources/MultipleClassDirs.gradle
@@ -1,0 +1,9 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+sourceSets.main.output.addClassesDir { -> file('build/classes/java/second') }

--- a/src/test/resources/SourceAnalysisProperty.gradle
+++ b/src/test/resources/SourceAnalysisProperty.gradle
@@ -1,0 +1,16 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+sourceSets {
+  main {
+    java.srcDirs = ['src/main/java']
+  }
+}
+tasks.withType(com.github.spotbugs.SpotBugsTask) {
+  jvmArgs = ['-Dfindbugs.sf.comment=true']
+}

--- a/src/test/resources/SpotBugsPlugin.gradle
+++ b/src/test/resources/SpotBugsPlugin.gradle
@@ -1,0 +1,9 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+if(project.hasProperty('ignoreFailures')) { spotbugs.ignoreFailures = true }


### PR DESCRIPTION
Extract Gradle file into separated resource file. I wish [Raw String Literal](https://openjdk.java.net/jeps/326) will come to Java later...

I also deleted needless usage of local maven repository. I also removed the code that fixes spotbugs Gradle plugin version to `1.6.1`.