### PR TITLE
Release 1.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
+## Unreleased - 2019-??-??
+
 ## 1.6.9 - 2019-01-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
-## Unreleased
+## 1.6.9 - 2019-01-04
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## License
 
-Copyright 2017-2018 the original author or authors.
+Copyright 2017-2019 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -16,7 +16,7 @@ This commit will be tagged with version number. Refer [db979662](https://github.
 Create a commit to handle following changes:
 
 * change `version` in `build.gradle` to SNAPSHOT version
-* add `Unreleased - 2018-??-??` into `CHANGELOG.md`
+* add `Unreleased - 2019-??-??` into `CHANGELOG.md`
 
 Refer [ef63f198](https://github.com/spotbugs/spotbugs-gradle-plugin/commit/ef63f1980d75a1999af00b3505667f3932c8c0fa) as example.
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 
-version = '1.6.9-SNAPSHOT'
+version = '1.6.9'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.10'
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 
-version = '1.6.9'
+version = '1.6.10-SNAPSHOT'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.10'
 sourceCompatibility = 1.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This patch update contains one fix #88.

We've also updated build system to ensure that it works with Gradle 5.1, however we have no change in distributions because Gradle community kept the backward compatibility.