### PR TITLE
Make task cacheable across checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2019-??-??
 
+### Fixed
+
+* Result caching works across checkouts. Previously it was using absolute paths and therefore didn't work. ([#96](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/96))
+
 ## 1.6.9 - 2019-01-04
 
 ### Fixed

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -324,7 +324,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
         return super.getSource();
     }
 
-    @Input
+    @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     FileCollection getAllSource() {
         return getProject().files(sourceDirs).plus(getSource());


### PR DESCRIPTION
allSource input creates different cache keys for same project checked out at different locations. This PR will fix it.