### PR TITLE
Fix #31 around text type bug report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 * "Trying to add already registered factory" problem reported as [a spotbugs issue](https://github.com/spotbugs/spotbugs/issues/819)
 * Result caching works across checkouts. Previously it was using absolute paths and therefore didn't work. ([#96](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/96))
-* Restore compatiblity with Gradle 4.0~4.6 ([#101](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/101))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 * "Trying to add already registered factory" problem reported as [a spotbugs issue](https://github.com/spotbugs/spotbugs/issues/819)
 * Result caching works across checkouts. Previously it was using absolute paths and therefore didn't work. ([#96](https://github.com/spotbugs/spotbugs-gradle-plugin/pull/96))
+* Support text type bug report ([#31](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/31))
 
 ### Removed
 

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
@@ -178,7 +178,11 @@ public class SpotBugsSpecBuilder {
                         outputArg += ':' + r.getStylesheet().asFile().getAbsolutePath();
                     }
                 }
-                args.add(outputArg);
+                if ("-text".equals(outputArg)) {
+                  // text mode is default behaviour of SpotBugs, then no need to add argument
+                } else {
+                  args.add(outputArg);
+                }
                 args.add("-outputFile");
                 args.add(reportsImpl.getFirstEnabled().getDestination().getAbsolutePath());
             } else {

--- a/src/test/java/com/github/spotbugs/Issue31Test.java
+++ b/src/test/java/com/github/spotbugs/Issue31Test.java
@@ -1,0 +1,63 @@
+/*
+ * Contributions to SpotBugs
+ * Copyright (C) 2018, Kengo TODA
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+package com.github.spotbugs;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs-gradle-plugin/issues/31">GitHub issue</a>
+ */
+public class Issue31Test {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void createProject() throws IOException {
+      Files.copy(Paths.get("src/test/resources/Issue31.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+          StandardCopyOption.COPY_ATTRIBUTES);
+
+      File sourceDir = folder.newFolder("src", "main", "java");
+      File to = new File(sourceDir, "Foo.java");
+      File from = new File("src/test/java/com/github/spotbugs/Foo.java");
+      Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+    @Test
+    public void test() throws Exception {
+        BuildResult result = GradleRunner.create().withProjectDir(folder.getRoot())
+                .withArguments(Arrays.asList("spotbugsMain")).withPluginClasspath().build();
+    }
+}

--- a/src/test/resources/Issue31.gradle
+++ b/src/test/resources/Issue31.gradle
@@ -1,0 +1,14 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+version = 1.0
+repositories {
+  mavenCentral()
+}
+spotbugsMain {
+    reports {
+        xml.enabled false
+        text.enabled true
+    }
+}


### PR DESCRIPTION
There is no ["-text" option](https://spotbugs.readthedocs.io/en/stable/running.html) in SpotBugs option. Just skip adding "-text" option when text report is activated via Gradle plugin. This PR will fix #31.