### PR TITLE
Remove no-op stream code

### DIFF
--- a/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -235,9 +235,6 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
              * all .class files available for analysis.
              */
             FileCollection presentClassDirs = sourceSet.getOutput().getClassesDirs().filter(File::exists);
-            StreamSupport.stream(presentClassDirs.spliterator(), false)
-                    .map(file -> project.fileTree(file))
-                    .forEach(tree -> tree.builtBy(sourceSet.getClassesTaskName()));
             return presentClassDirs.getAsFileTree();
         });
         taskMapping.map("classpath", sourceSet::getRuntimeClasspath);


### PR DESCRIPTION
This PR fixes #47. I think it needs no CHANGELOG entry because it doesn't affect any output from this plugin.