### PR TITLE
Fix sonarcloud related build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ addons:
     packages:
       - oracle-java8-installer
       - oracle-java8-set-default
+  sonarcloud:
+    organization: "spotbugs"
 
 install:
   - if [[ $GRADLE_VERSION != "default" ]]; then ./gradlew wrapper --gradle-version $GRADLE_VERSION; fi

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins{
   id 'groovy'
   id 'java-gradle-plugin'
   id "com.gradle.plugin-publish" version "0.9.7"
-  id 'org.sonarqube' version '2.6.2'
+  id 'org.sonarqube' version '2.7'
   id 'com.diffplug.gradle.spotless' version '3.18.0'
 }
 

--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -1,42 +1,10 @@
 apply plugin: 'org.sonarqube'
 
-// sonar should analyze project with single target branch only
-// In case feature branch should be analyzed, then sonar.branch variable should be specified
-def isMaster = 'master'.equals(System.env.TRAVIS_BRANCH)
-
-// for security reasons travis secure variables are defined when build is
-// initiated by a pull request from same repository only
-// so pull requests from external repositories can not be analysed by sonar
-def isSecure = 'true'.equals(System.env.TRAVIS_SECURE_ENV_VARS)
-
-if (!isSecure || !isMaster) {
-    rootProject.tasks['sonarqube'].setEnabled(false)
-    return
-}
-
-def isPush = 'push'.equals(System.env.TRAVIS_EVENT_TYPE);
-def isPullRequest = 'pull_request'.equals(System.env.TRAVIS_EVENT_TYPE);
-
-rootProject.tasks['sonarqube'].setEnabled(isPush || isPullRequest)
-
 sonarqube {
     properties {
-        property 'sonar.host.url', System.env.SONAR_HOST_URL
         property 'sonar.login', System.env.SONAR_LOGIN
         property 'sonar.projectKey', 'com.github.spotbugs.gradle'
         property 'sonar.projectName', 'SpotBugs Gradle Plugin'
         property 'sonar.projectVersion', rootProject.version
-        property 'sonar.organization', 'spotbugs'
-    }
-}
-
-if (isPullRequest) {
-    sonarqube {
-        properties {
-            property 'sonar.analysis.mode', 'preview'
-            property 'sonar.github.oauth', System.env.GITHUB_TOKEN
-            property 'sonar.github.pullRequest', System.env.TRAVIS_PULL_REQUEST
-            property 'sonar.github.repository', System.env.TRAVIS_REPO_SLUG
-        }
     }
 }


### PR DESCRIPTION
Current `gradle/sonar.gradle` uses removed feature: branch analysis and old pre-merge analysis. So the build in other PR is failed.
Both can be replaced by the official SonarCloud add-on, suggested by this PR.