### PR TITLE
feat: Improvements for HTML reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2019-??-??
 
+### Added
+
+* Add `-projectName` option ([#111](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/111))
+* Add `-release` option ([#111](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/111))
+* Add `setStylesheet(String)` that accepts relative path from the root of `spotbugs.jar` ([#107](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/107))
+
 ## 1.6.11 - 2019-03-10
 
 ### Changed

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -90,6 +90,8 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     private Collection<String> jvmArgs = new ArrayList<>();
 
+    private String release;
+
     @Nested
     private final SpotBugsReportsInternal reports;
 
@@ -279,6 +281,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
                 .withExcludeFilter(getExcludeFilter())
                 .withIncludeFilter(getIncludeFilter())
                 .withExcludeBugsFilter(getExcludeBugsFilter())
+                .withRelease(getRelease())
                 .withExtraArgs(getExtraArgs())
                 .withJvmArgs(getJvmArgs())
                 .configureReports(getReports());
@@ -666,5 +669,16 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     public void setJvmArgs(Collection<String> jvmArgs) {
         this.jvmArgs = jvmArgs;
+    }
+
+    public String getRelease() {
+        if (release == null) {
+            return String.valueOf(getProject().getVersion());
+        }
+        return release;
+    }
+
+    public void setRelease(String release) {
+        this.release = release;
     }
 }

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -47,6 +47,7 @@ import com.github.spotbugs.internal.spotbugs.SpotBugsSpec;
 import com.github.spotbugs.internal.spotbugs.SpotBugsSpecBuilder;
 import com.github.spotbugs.internal.spotbugs.SpotBugsWorkerManager;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import groovy.lang.Closure;
 
 /**
@@ -91,6 +92,10 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
     private Collection<String> jvmArgs = new ArrayList<>();
 
     private String release;
+
+    private String projectName;
+
+    private SourceSet sourceSet;
 
     @Nested
     private final SpotBugsReportsInternal reports;
@@ -282,6 +287,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
                 .withIncludeFilter(getIncludeFilter())
                 .withExcludeBugsFilter(getExcludeBugsFilter())
                 .withRelease(getRelease())
+                .withProjectName(getProjectName())
                 .withExtraArgs(getExtraArgs())
                 .withJvmArgs(getJvmArgs())
                 .configureReports(getReports());
@@ -344,6 +350,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     SpotBugsTask setSourceSet(SourceSet sourceSet) {
         this.sourceDirs = sourceSet.getAllJava().getSrcDirs();
+        this.sourceSet = sourceSet;
         setSource(sourceDirs);
         return this;
     }
@@ -671,14 +678,31 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
         this.jvmArgs = jvmArgs;
     }
 
+    @NonNull
     public String getRelease() {
-        if (release == null) {
-            return String.valueOf(getProject().getVersion());
+        if (release != null) {
+            return release;
         }
-        return release;
+        return String.valueOf(getProject().getVersion());
     }
 
     public void setRelease(String release) {
         this.release = release;
+    }
+
+    @NonNull
+    public String getProjectName() {
+        if (projectName != null) {
+            return projectName;
+        }
+        if (sourceSet == null) {
+            return String.valueOf(getProject().getDisplayName());
+        } else {
+            return String.format("%s (%s)", getProject().getDisplayName(), sourceSet.getName());
+        }
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
     }
 }

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -16,9 +16,9 @@ import org.gradle.api.tasks.Input;
 
 public class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
     private static final long serialVersionUID = 6474874842199703745L;
-    private transient final ResourceHandler handler;
-    private transient final Configuration configuration;
-    private transient final Logger logger;
+    private final transient ResourceHandler handler;
+    private final transient Configuration configuration;
+    private final transient Logger logger;
 
     /**
      * Null-able string representing relative file path of XSL packaged in spotbugs.jar.

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -16,9 +16,9 @@ import org.gradle.api.tasks.Input;
 
 public class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
     private static final long serialVersionUID = 6474874842199703745L;
-    private final ResourceHandler handler;
-    private final Configuration configuration;
-    private final Logger logger;
+    private transient final ResourceHandler handler;
+    private transient final Configuration configuration;
+    private transient final Logger logger;
 
     /**
      * Null-able string representing relative file path of XSL packaged in spotbugs.jar.

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -1,0 +1,60 @@
+package com.github.spotbugs.internal;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.reporting.internal.CustomizableHtmlReportImpl;
+import org.gradle.api.resources.ResourceHandler;
+import org.gradle.api.resources.TextResource;
+import org.gradle.api.resources.TextResourceFactory;
+import org.gradle.api.tasks.Input;
+
+public class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
+    private static final long serialVersionUID = 6474874842199703745L;
+    private final ResourceHandler handler;
+    private final Configuration configuration;
+    private final Logger logger;
+
+    /**
+     * Null-able string representing relative file path of XSL packaged in spotbugs.jar.
+     */
+    private String stylesheet;
+
+    public SpotBugsHtmlReportImpl(String name, Task task) {
+        super(name, task);
+        handler = task.getProject().getResources();
+        configuration = task.getProject().getConfigurations().getAt("spotbugs");
+        logger = task.getLogger();
+    }
+
+    @Input
+    public void setStylesheet(String fileName) {
+      this.stylesheet = fileName;
+    }
+
+    @Override
+    public TextResource getStylesheet() {
+        if (stylesheet == null) {
+            return super.getStylesheet();
+        }
+
+        TextResourceFactory factory = handler.getText();
+        Optional<File> spotbugs = configuration.files(this::find).stream().findFirst();
+        if (spotbugs.isPresent()) {
+            File jar = spotbugs.get();
+            logger.debug("Specified stylesheet ({}) found in spotbugs configuration: {}", stylesheet, jar.getAbsolutePath());
+            return factory.fromArchiveEntry(jar, stylesheet);
+        } else {
+            throw new InvalidUserDataException("Specified stylesheet (" + stylesheet + ") does not found in spotbugs configuration");
+        }
+    }
+
+    private boolean find(Dependency d) {
+        return "com.github.spotbugs".equals(d.getGroup()) && "spotbugs".equals(d.getName());
+    }
+}

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsReportsImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsReportsImpl.java
@@ -2,7 +2,6 @@ package com.github.spotbugs.internal;
 
 import org.gradle.api.Task;
 import org.gradle.api.reporting.SingleFileReport;
-import org.gradle.api.reporting.internal.CustomizableHtmlReportImpl;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 import org.gradle.api.reporting.internal.TaskReportContainer;
 
@@ -11,11 +10,11 @@ import com.github.spotbugs.internal.spotbugs.SpotBugsXmlReportImpl;
 
 public class SpotBugsReportsImpl extends TaskReportContainer<SingleFileReport> implements SpotBugsReportsInternal {
 
-  public SpotBugsReportsImpl(Task task) {
+public SpotBugsReportsImpl(Task task) {
       super(SingleFileReport.class, task);
 
       add(SpotBugsXmlReportImpl.class, "xml", task);
-      add(CustomizableHtmlReportImpl.class, "html", task);
+      add(SpotBugsHtmlReportImpl.class, "html", task);
       add(TaskGeneratedSingleFileReport.class, "text", task);
       add(TaskGeneratedSingleFileReport.class, "emacs", task);
   }

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
@@ -40,6 +40,7 @@ public class SpotBugsSpecBuilder {
     private Collection<String> jvmArgs;
     private boolean showProgress;
     private boolean debugEnabled;
+	private String release;
 
     public SpotBugsSpecBuilder(FileCollection classes) {
         if (classes == null || classes.isEmpty()) {
@@ -151,6 +152,11 @@ public class SpotBugsSpecBuilder {
         return this;
     }
 
+    public SpotBugsSpecBuilder withRelease(@Nullable String release) {
+        this.release = release;
+        return this;
+    }
+
     public SpotBugsSpec build() {
         ArrayList<String> args = new ArrayList<>();
         args.add("-pluginList");
@@ -232,6 +238,11 @@ public class SpotBugsSpecBuilder {
         if (has(excludeBugsFilter)) {
             args.add("-excludeBugs");
             args.add(excludeBugsFilter.getPath());
+        }
+
+        if (has(release)) {
+            args.add("-release");
+            args.add(release);
         }
 
         if (has(extraArgs)) {

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsSpecBuilder.java
@@ -40,7 +40,8 @@ public class SpotBugsSpecBuilder {
     private Collection<String> jvmArgs;
     private boolean showProgress;
     private boolean debugEnabled;
-	private String release;
+    private String release;
+    private String projectName;
 
     public SpotBugsSpecBuilder(FileCollection classes) {
         if (classes == null || classes.isEmpty()) {
@@ -157,6 +158,11 @@ public class SpotBugsSpecBuilder {
         return this;
     }
 
+    public SpotBugsSpecBuilder withProjectName(@Nullable String projectName) {
+        this.projectName = projectName;
+        return this;
+    }
+
     public SpotBugsSpec build() {
         ArrayList<String> args = new ArrayList<>();
         args.add("-pluginList");
@@ -243,6 +249,11 @@ public class SpotBugsSpecBuilder {
         if (has(release)) {
             args.add("-release");
             args.add(release);
+        }
+
+        if (has(projectName)) {
+            args.add("-projectName");
+            args.add(projectName);
         }
 
         if (has(extraArgs)) {

--- a/src/test/java/com/github/spotbugs/HtmlReportTest.java
+++ b/src/test/java/com/github/spotbugs/HtmlReportTest.java
@@ -31,6 +31,7 @@ public class HtmlReportTest {
       File to = new File(sourceDir, "Foo.java");
       File from = new File("src/test/java/com/github/spotbugs/Foo.java");
       Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
+      Files.write(folder.newFile("settings.gradle").toPath(), "rootProject.name = 'my project name'".getBytes());
     }
 
     @Test
@@ -38,8 +39,17 @@ public class HtmlReportTest {
         GradleRunner.create().withProjectDir(folder.getRoot())
                 .withArguments(Arrays.asList("spotbugsMain")).withPluginClasspath().build();
         Path report = folder.getRoot().toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.html");
-        String html = Files.readAllLines(report).stream().collect(Collectors.joining());
+        String html = Files.readAllLines(report).stream().collect(Collectors.joining("\n"));
         assertThat(html, containsString("\"1.2.3\""));
+    }
+
+    @Test
+    public void testReportContainsProjectName() throws Exception {
+        GradleRunner.create().withProjectDir(folder.getRoot())
+                .withArguments(Arrays.asList("spotbugsMain")).withPluginClasspath().build();
+        Path report = folder.getRoot().toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.html");
+        String html = Files.readAllLines(report).stream().collect(Collectors.joining("\n"));
+        assertThat(html, containsString("'my project name' (main)"));
     }
 
 }

--- a/src/test/java/com/github/spotbugs/HtmlReportTest.java
+++ b/src/test/java/com/github/spotbugs/HtmlReportTest.java
@@ -1,0 +1,45 @@
+package com.github.spotbugs;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class HtmlReportTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void createProject() throws IOException {
+      Files.copy(Paths.get("src/test/resources/HtmlReportTest.gradle"), folder.getRoot().toPath().resolve("build.gradle"),
+          StandardCopyOption.COPY_ATTRIBUTES);
+
+      File sourceDir = folder.newFolder("src", "main", "java");
+      File to = new File(sourceDir, "Foo.java");
+      File from = new File("src/test/java/com/github/spotbugs/Foo.java");
+      Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+    @Test
+    public void testReportContainsVersion() throws Exception {
+        GradleRunner.create().withProjectDir(folder.getRoot())
+                .withArguments(Arrays.asList("spotbugsMain")).withPluginClasspath().build();
+        Path report = folder.getRoot().toPath().resolve("build").resolve("reports").resolve("spotbugs").resolve("main.html");
+        String html = Files.readAllLines(report).stream().collect(Collectors.joining());
+        assertThat(html, containsString("\"1.2.3\""));
+    }
+
+}

--- a/src/test/resources/HtmlReportTest.gradle
+++ b/src/test/resources/HtmlReportTest.gradle
@@ -2,8 +2,6 @@ plugins {
   id 'java'
   id 'com.github.spotbugs'
 }
-configurations { spotbugsStylesheets { transitive false } }
-dependencies { spotbugsStylesheets 'com.github.spotbugs:spotbugs:3.1.10' }
 version = '1.2.3'
 repositories {
   mavenCentral()
@@ -13,7 +11,7 @@ spotbugsMain {
         xml.enabled false
         html {
             enabled true
-            stylesheet resources.text.fromArchiveEntry(configurations.spotbugsStylesheets, 'fancy-hist.xsl')
+            stylesheet 'fancy-hist.xsl'
         }
     }
 }

--- a/src/test/resources/HtmlReportTest.gradle
+++ b/src/test/resources/HtmlReportTest.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'java'
+  id 'com.github.spotbugs'
+}
+configurations { spotbugsStylesheets { transitive false } }
+dependencies { spotbugsStylesheets 'com.github.spotbugs:spotbugs:3.1.10' }
+version = '1.2.3'
+repositories {
+  mavenCentral()
+}
+spotbugsMain {
+    reports {
+        xml.enabled false
+        html {
+            enabled true
+            stylesheet resources.text.fromArchiveEntry(configurations.spotbugsStylesheets, 'fancy-hist.xsl')
+        }
+    }
+}


### PR DESCRIPTION
Support `-projectName` and `-release` option that makes reporting better. By default, it uses project name and version.

Also add `setStylesheet(String)` for HTML report: For now we only has `setStylesheet(TextResource)` but XSL is packaged into `spotbugs.jar` then it is good to support the path for zip entries.

This PR closes #111. Also close #107.