### PR TITLE
WIP: use TRAVIS_SECURE_ENV_VARS instead to judge condition to run Sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
   include:
     - stage: analyze
       script: ./gradlew sonarqube -S
-      if: env(TRAVIS_SECURE_ENV_VARS) IS true
+      if: fork == false
     - stage: deploy
       name: Deploy to Gradle Plugin Portal
       script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
   include:
     - stage: analyze
       script: ./gradlew sonarqube -S
-      if: env(SONAR_LOGIN) IS present
+      if: env(TRAVIS_SECURE_ENV_VARS) IS true
     - stage: deploy
       name: Deploy to Gradle Plugin Portal
       script: skip


### PR DESCRIPTION
This PR is made from the branch in the different repo. It should not run the SonarQube analysis.