### PR TITLE
Release v2.0.0 for Gradle 6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
+## Unreleased - 2019-??-??
+
 ## 2.0.0 - 2019-05-13
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
-## Unreleased - 2019-??-??
+## 2.0.0 - 2019-05-13
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2019-??-??
 
+### Removed
+
+* Gradle 5.0 support
+
 ## 1.7.1 - 2019-03-14
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 
-version = '2.0.0-SNAPSHOT'
+version = '2.0.0'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.12'
 def slf4jVersion = '1.8.0-beta4'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 
-version = '2.0.0'
+version = '2.0.1-SNAPSHOT'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.12'
 def slf4jVersion = '1.8.0-beta4'


### PR DESCRIPTION
Gradle 6 will remove deprecated API, then this release will be required for Gradle 6 users.
Note that Gradle 6 hasn't been released yet, but the last release for Gradle 5 (5.5) is coming.

This version works with Gradle 5.1+.