### PR TITLE
Allow projects without a SourceSet (Eg. Android) to use this SpotBugs…

### DIFF
--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -61,7 +62,8 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     private FileCollection classpath;
 
-    private Set<File> sourceDirs;
+    //Initialize it to an empty set to allow projects without a Sourceset to use this task.
+    private Set<File> sourceDirs = Collections.emptySet();
 
     private FileCollection spotbugsClasspath;
 


### PR DESCRIPTION
…Task

If a project does not contain a sourceset, the execution of type SpotBugsTask fails with `path may not be null or empty string. path='null'` error.
This is because the sourceset is passed as an `@InputFiles` and it is null.