### PR TITLE
Update plugin to build with Gradle 6.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins{
   id 'java-gradle-plugin'
   id "com.gradle.plugin-publish" version "0.10.1"
   id 'org.sonarqube' version '2.7.1'
-  id 'com.diffplug.gradle.spotless' version '3.24.1'
+  id 'com.diffplug.gradle.spotless' version '3.24.2'
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
@@ -25,12 +25,12 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    implementation gradleApi()
+    implementation localGroovy()
     compileOnly "com.github.spotbugs:spotbugs:${spotBugsVersion}"
 
-    testCompile gradleTestKit()
-    testCompile 'junit:junit:4.12'//, 'org.spockframework:spock-core:1.0-groovy-2.4'
+    testImplementation gradleTestKit()
+    testImplementation 'junit:junit:4.12'//, 'org.spockframework:spock-core:1.0-groovy-2.4'
 }
 
 test {

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -1,6 +1,6 @@
 // see https://central.sonatype.org/pages/gradle.html
 
-apply plugin: 'maven'
+apply plugin: 'maven' //TODO: replace with maven-publish: The maven plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the maven-publish plugin instead.
 apply plugin: 'signing'
 
 task javadocJar(type: Jar) {

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -464,7 +464,6 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
      * @return true iff progress report is enabled
      */
     @Input
-    @Optional
     public boolean getShowProgress() {
         return showProgress;
     }


### PR DESCRIPTION
Hi!

Few things for Gradle 6 support:

* Upgrade `com.diffplug.gradle.spotless` to `3.24.2`
   * Older versions fail in Gradle 6.x with the following: 
   > Execution failed for task ':spotlessJava'. You must declare outputs or use `TaskOutputs.upToDateWhen()` when using the incremental task API

* Remove `@Optional` from `showProgress` in `SpotBugsTask`.
   * Reason:  @Input properties with primitive type 'boolean' cannot be @Optional.

* Replace `compile` and `testCompile` with `implementation` and `testImplementation` as the former will be removed in Gradle 7.0 and now they trigger warnings on builds
