### PR TITLE
Validate when plugin is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog v1.0.0](http://keepachangelog.com/en/1.0.0/).
@@ -5,6 +6,10 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
 ## Unreleased - 2019-??-??
+
+### Fixed
+
+* Avoid needless task creation (#165)
 
 ## 2.0.0 - 2019-05-13
 

--- a/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.FileCollection;
@@ -61,37 +60,6 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
     protected void beforeApply() {
         verifyGradleVersion(GradleVersion.current());
         configureSpotBugsConfigurations();
-        project.afterEvaluate(this::verify);
-    }
-
-    private void verify(Project p) {
-        p.getTasks().withType(SpotBugsTask.class).forEach(task -> {
-            SpotBugsReports reports = task.getReports();
-            if (reports.getText() != null && reports.getText().getDestination() == null) {
-                String message = String.format(
-                        "Task '%s' has no destination for TEXT report. Set reports.text.destination to this task.",
-                        task.getName());
-                throw new IllegalStateException(message);
-            }
-            if (reports.getXml() != null && reports.getXml().getDestination() == null) {
-                String message = String.format(
-                        "Task '%s' has no destination for XML report. Set reports.xml.destination to this task.",
-                        task.getName());
-                throw new IllegalStateException(message);
-            }
-            if (reports.getHtml() != null && reports.getHtml().getDestination() == null) {
-                String message = String.format(
-                        "Task '%s' has no destination for HTML report. Set reports.html.destination. to this task",
-                        task.getName());
-                throw new IllegalStateException(message);
-            }
-            if (reports.getEmacs() != null && reports.getEmacs().getDestination() == null) {
-                String message = String.format(
-                        "Task '%s' has no destination for EMACS report. Set reports.emacs.destination. to this task",
-                        task.getName());
-                throw new IllegalStateException(message);
-            }
-        });
     }
 
     /**

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -10,7 +10,11 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.gradle.api.*;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Incubating;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.LogLevel;

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -10,10 +10,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.gradle.api.Action;
-import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
-import org.gradle.api.JavaVersion;
+import org.gradle.api.*;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.LogLevel;
@@ -186,7 +183,23 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
     @Override
     public SpotBugsReports reports(Action<? super SpotBugsReports> configureAction) {
         configureAction.execute(reports);
+        verify(reports);
         return reports;
+    }
+
+    private void verify(SpotBugsReportsInternal reports) {
+        if (reports.getText() != null && reports.getText().getDestination() == null) {
+            throw new InvalidUserDataException("No destination for TEXT report. Set reports.text.destination to this task.");
+        }
+        if (reports.getXml() != null && reports.getXml().getDestination() == null) {
+            throw new InvalidUserDataException("No destination for XML report. Set reports.xml.destination to this task.");
+        }
+        if (reports.getHtml() != null && reports.getHtml().getDestination() == null) {
+            throw new InvalidUserDataException("No destination for HTML report. Set reports.html.destination to this task.");
+        }
+        if (reports.getEmacs() != null && reports.getEmacs().getDestination() == null) {
+            throw new InvalidUserDataException("No destination for EMACS report. Set reports.emacs.destination to this task.");
+        }
     }
 
     /**

--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -193,16 +193,16 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
 
     private void verify(SpotBugsReportsInternal reports) {
         if (reports.getText() != null && reports.getText().getDestination() == null) {
-            throw new InvalidUserDataException("No destination for TEXT report. Set reports.text.destination to this task.");
+            throw new InvalidUserDataException("No destination found for TEXT report. Set reports.text.destination to this task.");
         }
         if (reports.getXml() != null && reports.getXml().getDestination() == null) {
-            throw new InvalidUserDataException("No destination for XML report. Set reports.xml.destination to this task.");
+            throw new InvalidUserDataException("No destination found for XML report. Set reports.xml.destination to this task.");
         }
         if (reports.getHtml() != null && reports.getHtml().getDestination() == null) {
-            throw new InvalidUserDataException("No destination for HTML report. Set reports.html.destination to this task.");
+            throw new InvalidUserDataException("No destination found for HTML report. Set reports.html.destination to this task.");
         }
         if (reports.getEmacs() != null && reports.getEmacs().getDestination() == null) {
-            throw new InvalidUserDataException("No destination for EMACS report. Set reports.emacs.destination to this task.");
+            throw new InvalidUserDataException("No destination found for EMACS report. Set reports.emacs.destination to this task.");
         }
     }
 

--- a/src/test/java/com/github/spotbugs/Issue423Test.java
+++ b/src/test/java/com/github/spotbugs/Issue423Test.java
@@ -60,6 +60,6 @@ public class Issue423Test {
                 .withArguments(Arrays.asList("classes", "spotbugs")).withPluginClasspath().buildAndFail();
         assertThat(result.getOutput(),
                 containsString(
-                        "Task 'spotbugs' has no destination for XML report. Set reports.xml.destination to this task."));
+                        "No destination found for XML report. Set reports.xml.destination to this task."));
     }
 }


### PR DESCRIPTION
Current way create task instances even though it is not necessary.
This PR applies the same way with [the official CodeNarc plugin validating configuration in setter method](https://github.com/gradle/gradle/blob/df7ac484a2facbb4503ba911666367de22b1d16a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcExtension.java).

This PR also changes the type of Exception from `IllegalStateException` to `IllegalUserDataException` that is recommended to make problem clear. This is also the same way with the plugin in above.

@daanschipper can I ask you to confirm this fix?