### PR TITLE
Gradle 6.1 support: make Html and Xml report implementation abstract so Gradle decorates the

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ jdk:
 env:
   matrix:
     - GRADLE_VERSION=default
-    - GRADLE_VERSION=5.1
     - GRADLE_VERSION=5.2
     - GRADLE_VERSION=5.3
     - GRADLE_VERSION=5.4
     - GRADLE_VERSION=5.5
+    - GRADLE_VERSION=5.6
   global:
     - SONAR_HOST_URL="https://sonarcloud.io"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsPlugin.java
@@ -42,7 +42,7 @@ public class SpotBugsPlugin extends AbstractCodeQualityPlugin<SpotBugsTask> {
      *
      * Package-protected access is for testing purposes
      */
-    static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("5.1");
+    static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("5.2");
 
     private SpotBugsExtension extension;
 

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -14,7 +14,7 @@ import org.gradle.api.resources.TextResource;
 import org.gradle.api.resources.TextResourceFactory;
 import org.gradle.api.tasks.Input;
 
-public class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
+public abstract class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
     private static final long serialVersionUID = 6474874842199703745L;
     private final transient ResourceHandler handler;
     private final transient Configuration configuration;

--- a/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsXmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsXmlReportImpl.java
@@ -5,7 +5,7 @@ import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 
 import com.github.spotbugs.SpotBugsXmlReport;
 
-public class SpotBugsXmlReportImpl extends TaskGeneratedSingleFileReport implements SpotBugsXmlReport {
+public abstract class SpotBugsXmlReportImpl extends TaskGeneratedSingleFileReport implements SpotBugsXmlReport {
   private static final long serialVersionUID = 1L;
   private boolean withMessages;
 

--- a/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
+++ b/src/test/java/com/github/spotbugs/SpotBugsPluginTest.java
@@ -147,7 +147,7 @@ public class SpotBugsPluginTest extends Assert{
         plugin.verifyGradleVersion(GradleVersion.version("5.0"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testVersionVerifyForGradleVersion51() {
         SpotBugsPlugin plugin = new SpotBugsPlugin();
         plugin.verifyGradleVersion(GradleVersion.version("5.1"));


### PR DESCRIPTION
Hi!

With Gradle 6.1 around the corner, this is a potential issue: https://github.com/gradle/gradle/issues/11189

```
/home/travis/build/spotbugs/spotbugs-gradle-plugin/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java:17: error: SpotBugsHtmlReportImpl is not abstract and does not override abstract method getOutputLocation() in SimpleReport
public class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
       ^
/home/travis/build/spotbugs/spotbugs-gradle-plugin/src/main/java/com/github/spotbugs/internal/spotbugs/SpotBugsXmlReportImpl.java:8: error: SpotBugsXmlReportImpl is not abstract and does not override abstract method getOutputLocation() in SimpleReport
public class SpotBugsXmlReportImpl extends TaskGeneratedSingleFileReport implements SpotBugsXmlReport {
       ^
2 errors


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.
```

One of the suggestions is to make `SpotBugsHtmlReportImpl` and `SpotBugsXmlReportImpl` abstract so Gradle decorates them accordingly. 

This will prevent the need for implementing new methods at `Report` interface (and others) level.

Downside, minimum supported version would be Gradle 5.2:

```
* What went wrong:
A problem occurred configuring root project 'junit3075643674612972315'.
> Could not create task ':spotbugsMain'.
   > Could not create task of type 'SpotBugsTask'.
      > Could not create an instance of type com.github.spotbugs.internal.SpotBugsReportsImpl_Decorated.
         > Cannot create a proxy class for abstract class 'SpotBugsXmlReportImpl'.

``` 

