### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2019-??-??
 
+### Added
+
+* Gradle 6.1 support ([#174](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/174))
+
+### Removed
+
+* Gradle 5.1 support ([#174](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/174))
+
 ## 2.0.1 - 2019-10-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
+## Unreleased - 2019-??-??
+
 ## 3.0.0 - 2019-11-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This is the changelog for SpotBugs Gradle Plugin. This follows [Keep a Changelog
 
 Currently the versioning policy of this project follows [Semantic Versioning](http://semver.org/) from version 1.6.0.
 
-## Unreleased - 2019-??-??
+## 3.0.0 - 2019-11-14
 
 ### Added
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 
-version = '2.0.2-SNAPSHOT'
+version = '3.0.0'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.12'
 def slf4jVersion = '1.8.0-beta4'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/sonar.gradle"
 apply from: "$rootDir/gradle/deploy.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 
-version = '3.0.0'
+version = '3.0.1-SNAPSHOT'
 group = "com.github.spotbugs"
 def spotBugsVersion = '3.1.12'
 def slf4jVersion = '1.8.0-beta4'


### PR DESCRIPTION
To support Gradle 6.1, we need to drop support for 5.1.
To release this breaking change, I will bump up the major version to 3.