### PR TITLE
Fixes deprecation warning when using Gradle 6. Resolves #171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Currently the versioning policy of this project follows [Semantic Versioning](ht
 
 ## Unreleased - 2019-??-??
 
+### Fixed
+
+* Deprecation warning in Gradle 6 ([#171](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/171))
+
 ## 2.0.1 - 2019-10-16
 
 ### Fixed

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -12,7 +12,7 @@ import org.gradle.api.reporting.internal.CustomizableHtmlReportImpl;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.resources.TextResourceFactory;
-import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
 
 public abstract class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
     private static final long serialVersionUID = 6474874842199703745L;
@@ -32,11 +32,11 @@ public abstract class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl 
         logger = task.getLogger();
     }
 
-    @Input
     public void setStylesheet(String fileName) {
       this.stylesheet = fileName;
     }
 
+    @Nested
     @Override
     public TextResource getStylesheet() {
         if (stylesheet == null) {


### PR DESCRIPTION
I think `@Nested` is the correct annotation but my experience with writing gradle plugins is limited so feel free to correct me.