### PR TITLE
Remove @Input from setStylesheet as it is deprecated behavior

### DIFF
--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -12,7 +12,6 @@ import org.gradle.api.reporting.internal.CustomizableHtmlReportImpl;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.resources.TextResourceFactory;
-import org.gradle.api.tasks.Input;
 
 public abstract class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl {
     private static final long serialVersionUID = 6474874842199703745L;
@@ -32,11 +31,10 @@ public abstract class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl 
         logger = task.getLogger();
     }
 
-    @Input
     public void setStylesheet(String fileName) {
       this.stylesheet = fileName;
     }
-
+    
     @Override
     public TextResource getStylesheet() {
         if (stylesheet == null) {

--- a/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
+++ b/src/main/java/com/github/spotbugs/internal/SpotBugsHtmlReportImpl.java
@@ -34,7 +34,7 @@ public abstract class SpotBugsHtmlReportImpl extends CustomizableHtmlReportImpl 
     public void setStylesheet(String fileName) {
       this.stylesheet = fileName;
     }
-    
+
     @Override
     public TextResource getStylesheet() {
         if (stylesheet == null) {


### PR DESCRIPTION
This is not a priority, found this when using spotbugs lately:

```
 Task :spotbugsMain
Type 'SpotBugsHtmlReportImpl': setter method 'setStylesheet()' should not be annotated with: @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
	at java.lang.Iterable.forEach(Iterable.java:75)
	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:56)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.lambda$execute$2(SkipEmptyWorkStep.java:78)
``` 