### PR TITLE
Force classification of a build failure as a verification failure

### DIFF
--- a/src/main/java/com/github/spotbugs/SpotBugsTask.java
+++ b/src/main/java/com/github/spotbugs/SpotBugsTask.java
@@ -322,7 +322,7 @@ public class SpotBugsTask extends SourceTask implements VerificationTask, Report
         }
 
         if (result.getBugCount() > 0) {
-            String message = "SpotBugs rule violations were found.";
+            String message = "Verification failed: SpotBugs rule violations were found.";
             SingleFileReport report = reports.getFirstEnabled();
             if (report != null) {
                 String reportUrl = new ConsoleRenderer().asClickableFileUrl(report.getDestination());


### PR DESCRIPTION
When using Gradle Enterprise, builds failing due to Spotbugs violations were incorrectly classified as non-verification failures.

To classify failing builds due to Spotbugs violations, the exception message
should be prefixed. For more information see https://docs.gradle.com/enterprise/failure-classification/

The message can be prefixed with any of the following phrases, let me know if you would like a different one!
* Analysis failed
* Check failed
* Compilation failed
* Code generation failed
* Generation failed
* Lint failed
* Processing failed
* Test failed
* Tests failed
* Testing failed
* Verification failed