### PR TITLE
Try to reproduce the reported case, and fix it

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/Issue196.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/Issue196.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 SpotBugs team
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.spotbugs.snom
+
+import org.gradle.internal.impldep.com.google.common.io.Files
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+import org.junit.jupiter.api.BeforeEach
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Paths
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * https://github.com/lazystone/spotbugs-bugs/blob/master/build.gradle.kts
+ * https://github.com/spotbugs/spotbugs-gradle-plugin/issues/196
+ */
+class Issue196 extends Specification {
+    File rootDir
+    File buildFile
+    String version = System.getProperty('snom.test.functional.gradle', GradleVersion.current().version)
+
+    @BeforeEach
+    def setup() {
+        rootDir = Files.createTempDir()
+        buildFile = new File(rootDir, 'build.gradle.kts')
+        buildFile << """
+plugins {
+  id("com.github.spotbugs")
+  java
+}
+repositories {
+  mavenCentral()
+}
+        """
+        File sourceDir = rootDir.toPath().resolve("src").resolve("main").resolve("java").toFile()
+        sourceDir.mkdirs()
+        File sourceFile = new File(sourceDir, "Foo.java")
+        sourceFile << """
+public class Foo {
+    public static void main(String... args) {
+        System.out.println("Hello, SpotBugs!");
+    }
+}
+"""
+    }
+
+    def "can run analysis when check task is triggered"() {
+        when:
+        BuildResult result =
+                GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments("check", "--debug")
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+                .build()
+
+        then:
+        result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
+    }
+}

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -14,7 +14,6 @@
 package com.github.spotbugs.snom;
 
 import com.github.spotbugs.snom.internal.SpotBugsTaskFactory;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -33,20 +32,20 @@ public class SpotBugsPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.getPluginManager().apply(SpotBugsBasePlugin.class);
     SpotBugsExtension extension = project.getExtensions().findByType(SpotBugsExtension.class);
+    project
+        .getPluginManager()
+        .withPlugin(
+            "java-base",
+            javaBase -> {
+              log.debug(
+                  "The javaBase plugin has been applied, so making the check task depending on all of SpotBugsTask");
+              Task check = project.getTasks().getByName("check");
+              project.getTasks().withType(SpotBugsTask.class, check::dependsOn);
+            });
     createTasks(project, extension);
   }
 
   private void createTasks(Project project, SpotBugsExtension extension) {
-    @Nullable Task check = project.getTasks().findByName("check");
-    log.debug("check task {}", check == null ? "not found" : "found");
-    new SpotBugsTaskFactory()
-        .generate(
-            project,
-            task -> {
-              if (check != null) {
-                check.dependsOn(task);
-              }
-              task.init(extension);
-            });
+    new SpotBugsTaskFactory().generate(project, task -> task.init(extension));
   }
 }


### PR DESCRIPTION
This fix makes SpotBugs plugin makes the dependency onto `check` task when `java-base` plugin is applied. This change close #196 in the version `4.0.1` which expects that `java-base` plugin is already applied to the project.