### PR TITLE
fix: bump up SpotBugs to 4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
 | 4.0.0| 4.0.0|
+| 4.0.5| 4.0.1|
 
 ## Copyright
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.3.4'
-    spotBugsVersion = '4.0.0'
+    spotBugsVersion = '4.0.1'
     slf4jVersion = '1.8.0-beta4'
     androidGradlePluginVersion = '3.5.3'
 }


### PR DESCRIPTION
SpotBugs 4.0.1 is released: https://github.com/spotbugs/spotbugs/releases/tag/4.0.1