### PR TITLE
fix: mandatory update for plugin portal publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'groovy'
     id 'java-gradle-plugin'
     id 'jacoco'
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '0.11.0'
     id 'com.diffplug.gradle.spotless' version '3.27.2'
     id 'net.ltgt.errorprone' version '1.1.1'
     id 'se.patrikerdes.use-latest-versions' version '0.2.13'


### PR DESCRIPTION
More info https://blog.gradle.org/plugin-portal-update