### PR TITLE
Bump up the default toolVersion to 4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
-| 4.0.6| 4.0.2|
+| 4.0.7| 4.0.2|
 | 4.0.0| 4.0.0|
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
+| 4.0.6| 4.0.2|
 | 4.0.0| 4.0.0|
 
 ## Copyright

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.3.4'
-    spotBugsVersion = '4.0.0'
+    spotBugsVersion = '4.0.2'
     slf4jVersion = '1.8.0-beta4'
     androidGradlePluginVersion = '3.5.3'
 }


### PR DESCRIPTION
SpotBugs 4.0.2 is out, so bump up the default `toolVersion` to it.
https://github.com/spotbugs/spotbugs/releases/tag/4.0.2