### PR TITLE
fix: Use task creation avoidance api

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
@@ -47,7 +47,7 @@ public class SpotBugsTaskFactory {
                         log.debug("Creating SpotBugsTask for {}", sourceSet);
                         project
                             .getTasks()
-                            .create(
+                            .register(
                                 name,
                                 SpotBugsTask.class,
                                 task -> {


### PR DESCRIPTION
Using `getTasks().register()` avoids creating the tasks during configuration time.
Currently the plugin is creating  number of modules * number of sourcesets amount of tasks, slowing down the configuration time.

![Tasks created during configuration time, from a build scan](https://user-images.githubusercontent.com/2778477/80195459-25d2ce00-861c-11ea-9d02-00140d649eea.png)

How can I build the plugin to test it locally to confirm that this solves the issue?
