### PR TITLE
feat: add support for auxclasspathFromFile in java process

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -144,6 +144,9 @@ class SpotBugsExtension {
     @NonNull
     final Property<String> toolVersion
 
+    @NonNull
+    final Property<Boolean> useAuxclasspathFile;
+
     @Inject
     SpotBugsExtension(Project project, ObjectFactory objects) {
         ignoreFailures = objects.property(Boolean).convention(false);
@@ -173,6 +176,7 @@ class SpotBugsExtension {
         extraArgs = objects.listProperty(String);
         maxHeapSize = objects.property(String);
         toolVersion = objects.property(String)
+        useAuxclasspathFile = objects.property(Boolean).convention(false)
     }
 
     void setReportLevel(@Nullable String name) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -229,6 +229,15 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     FileCollection auxClassPaths;
 
+    /**
+     * Property to enable auxclasspathFromFile and prevent Argument List Too Long issues in java processes.
+     * Default value is {@code false}.
+     */
+    @Input
+    @Optional
+    @NonNull
+    final Property<Boolean> useAuxclasspathFile
+
     private FileCollection classes;
 
     void setClasses(FileCollection fileCollection) {
@@ -291,6 +300,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         jvmArgs = objects.listProperty(String);
         extraArgs = objects.listProperty(String);
         maxHeapSize = objects.property(String);
+        useAuxclasspathFile = objects.property(Boolean)
     }
 
     /**
@@ -316,6 +326,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         jvmArgs.convention(extension.jvmArgs)
         extraArgs.convention(extension.extraArgs)
         maxHeapSize.convention(extension.maxHeapSize)
+        useAuxclasspathFile.convention(extension.useAuxclasspathFile)
     }
 
     @TaskAction


### PR DESCRIPTION
Hi @KengoTODA 

This is to address https://github.com/spotbugs/spotbugs-gradle-plugin/issues/239

Found that having projects with massive classpaths can not be used with spotbugs plugin. For example:

```
17:29:09 Caused by: org.gradle.process.internal.ExecException: Process 'command '/usr/lib/jvm/zulu-8-amd64/bin/java'' could not be started because the command line exceed operating system limits.
17:29:09 	at org.gradle.process.internal.DefaultExecHandle.execExceptionFor(DefaultExecHandle.java:241)
17:29:09 	at org.gradle.process.internal.DefaultExecHandle.setEndStateInfo(DefaultExecHandle.java:218)
17:29:09 	at org.gradle.process.internal.DefaultExecHandle.failed(DefaultExecHandle.java:372)
17:29:09 	at org.gradle.process.internal.ExecHandleRunner.run(ExecHandleRunner.java:87)
17:29:09 	at org.gradle.internal.operations.CurrentBuildOperationPreservingRunnable.run(CurrentBuildOperationPreservingRunnable.java:42)
17:29:09 	... 3 more
17:29:09 Caused by: net.rubygrapefruit.platform.NativeException: Could not start '/usr/lib/jvm/zulu-8-amd64/bin/java'
17:29:09 	at net.rubygrapefruit.platform.internal.DefaultProcessLauncher.start(DefaultProcessLauncher.java:27)
17:29:09 	at net.rubygrapefruit.platform.internal.WrapperProcessLauncher.start(WrapperProcessLauncher.java:36)
17:29:09 	at org.gradle.process.internal.ExecHandleRunner.startProcess(ExecHandleRunner.java:98)
17:29:09 	at org.gradle.process.internal.ExecHandleRunner.run(ExecHandleRunner.java:71)
17:29:09 	... 4 more
17:29:09 Caused by: java.io.IOException: Cannot run program "/usr/lib/jvm/zulu-8-amd64/bin/java" (in directory "/agent/workspace/myproject"): error=7, Argument list too long
17:29:09 	at net.rubygrapefruit.platform.internal.DefaultProcessLauncher.start(DefaultProcessLauncher.java:25)
17:29:09 	... 7 more
17:29:09 Caused by: java.io.IOException: error=7, Argument list too long
```

While path jar is supported in gradle and can be overwritten via `      System.setProperty("org.gradle.internal.cmdline.max.length", CMDLINE_MAX_LENGTH);`, it is not enough since the classpath for the jar is small as it contains only the spotbugs/findbugs jars

 https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java#L45

which is invoked by https://github.com/gradle/gradle/blob/9e347dcbd00483d796e83c05c8b48d61dad06d0c/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java#L388 to determine if it should do path jar or not

However, the problem comes with java processes trying to use a long `auxclasspath`.

This is a sample of simple project:

```
0 = "-sortByClass"
1 = "-timestampNow"
2 = "-auxclasspath"
3 = "/Users/rperezalcolea/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/19.0/6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9/guava-19.0.jar"
4 = "-sourcepath"
5 = "/Users/rperezalcolea/Projects/bb/nebula/nebula/subprojects/core/build/nebulatest/netflix.nebula.spotbugs.NebulaSpotbugsCiPluginLauncherSpec/should-produce-html-reports-by-default/src/main/resources:/Users/rperezalcolea/Projects/bb/nebula/nebula/subprojects/core/build/nebulatest/netflix.nebula.spotbugs.NebulaSpotbugsCiPluginLauncherSpec/should-produce-html-reports-by-default/src/main/java"
6 = "-html"
7 = "-outputFile"
8 = "/Users/rperezalcolea/Projects/bb/nebula/nebula/subprojects/core/build/nebulatest/netflix.nebula.spotbugs.NebulaSpotbugsCiPluginLauncherSpec/should-produce-html-reports-by-default/build/reports/spotbugs/main.html"
9 = "-projectName"
10 = "should-produce-html-reports-by-default (spotbugsMain)"
11 = "-release"
12 = "unspecified"
13 = "-analyzeFromFile"
14 = "/var/folders/hb/c0ghc68d7vn26h4ny84kzv0r0000gn/T/spotbugs-gradle-plugin3618879618624022328.txt"
```

When these arguments are longer than `ARG_MAX` (2097152 on linux / 262144 OSX / 32767 windows) the process will fail.