### PR TITLE
feat: show spotbugs report full path when spotbugs execution fails

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
@@ -15,8 +15,10 @@ package com.github.spotbugs.snom.internal;
 
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.process.JavaExecSpec;
@@ -36,7 +38,15 @@ public class SpotBugsRunnerForJavaExec extends SpotBugsRunner {
       if (task.getIgnoreFailures()) {
         log.warn("SpotBugs reported failures", e);
       } else {
-        throw new GradleException("Verification failed: SpotBugs execution thrown exception", e);
+        String errorMessage = "Verification failed: SpotBugs execution thrown exception.";
+        List<String> reportPaths =
+            task.getReportsDir().getAsFileTree().getFiles().stream()
+                .map(File::getAbsolutePath)
+                .collect(Collectors.toList());
+        if (!reportPaths.isEmpty()) {
+          errorMessage += "SpotBugs report can be found in " + String.join(",", reportPaths);
+        }
+        throw new GradleException(errorMessage, e);
       }
     }
   }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -104,11 +104,11 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
                     + findReportPath());
           }
         }
-      } catch (GradleException gradleException) {
+      } catch (GradleException e) {
         if (params.getIgnoreFailures().getOrElse(Boolean.FALSE).booleanValue()) {
-          log.warn("SpotBugs reported failures", gradleException);
+          log.warn("SpotBugs reported failures", e);
         } else {
-          throw gradleException;
+          throw e;
         }
       } catch (Exception e) {
         throw new GradleException("Verification failed: SpotBugs execution thrown exception", e);

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.FindBugs;
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.TextUICommandLine;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.Objects;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
@@ -91,18 +92,36 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
           findBugs2.execute();
           if (findBugs2.getErrorCount() > 0) {
             throw new GradleException(
-                "Verification failed: SpotBugs error found: " + findBugs2.getErrorCount());
+                "Verification failed: SpotBugs error found: "
+                    + findBugs2.getErrorCount()
+                    + ". SpotBugs report can be found in "
+                    + findReportPath());
           } else if (findBugs2.getBugCount() > 0) {
             throw new GradleException(
-                "Verification failed: SpotBugs violation found: " + findBugs2.getBugCount());
+                "Verification failed: SpotBugs violation found: "
+                    + findBugs2.getBugCount()
+                    + ". SpotBugs report can be found in "
+                    + findReportPath());
           }
         }
-      } catch (Exception e) {
+      } catch (GradleException gradleException) {
         if (params.getIgnoreFailures().getOrElse(Boolean.FALSE).booleanValue()) {
-          log.warn("SpotBugs reported failures", e);
+          log.warn("SpotBugs reported failures", gradleException);
         } else {
-          throw new GradleException("Verification failed: SpotBugs execution thrown exception", e);
+          throw gradleException;
         }
+      } catch (Exception e) {
+        throw new GradleException("Verification failed: SpotBugs execution thrown exception", e);
+      }
+    }
+
+    private String findReportPath() {
+      List<String> arguments = getParameters().getArguments().get();
+      int outputFileParameterIndex = arguments.indexOf("-outputFile");
+      if (outputFileParameterIndex > 0) {
+        return arguments.get(outputFileParameterIndex + 1);
+      } else {
+        return null;
       }
     }
   }


### PR DESCRIPTION
Hi folks, this is for https://github.com/spotbugs/spotbugs-gradle-plugin/issues/245 

"Spotbugs report path should be provided in output when process fails"


Currently when running spotbugs and getting a failure, you can see the following:

```
3:38:34 * What went wrong:
03:38:34 Execution failed for task ':server:spotbugsMain'.
03:38:34 > A failure occurred while executing com.github.spotbugs.snom.internal.SpotBugsRunnerForWorker$SpotBugsExecutor
03:38:34    > Verification failed: SpotBugs execution thrown exception
03:38:34 
``` 

In order to get more details, `--stacktrace` has to be enabled and also you don't get details on where the report was added, if it was XML or HTML or something else.

I think it would be nice if the plugin outputs the full path when the execution fails