### PR TITLE
feat: Support for URL in the filter rules file just like maven FindBugs plugin #253

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -83,7 +83,7 @@ spotbugs {
         assertTrue(result.getOutput().contains("-include"))
         assertTrue(result.getOutput().contains(filter.getAbsolutePath()))
     }
-    
+
     def "can use includeFilter with URL"() {
         setup:
         File filter = new File(rootDir, "include.xml")
@@ -136,7 +136,7 @@ spotbugs {
         assertTrue(result.getOutput().contains("-exclude"))
         assertTrue(result.getOutput().contains(filter.getAbsolutePath()))
     }
-    
+
     def "can use excludeFilter with URL"() {
         setup:
         File filter = new File(rootDir, "exclude.xml")

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -106,10 +106,10 @@ spotbugs {
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
         assertTrue(result.getOutput().contains("-include"))
-        
+
         def filterPath = Paths.get(System.getProperty("java.io.tmpdir"), "spotBugs-includeFilter.xml").toString()
         def partialFilterPath = filterPath.replace('.xml','')
-        
+
         assertTrue(result.getOutput().contains(partialFilterPath))
     }
 
@@ -159,10 +159,10 @@ spotbugs {
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
         assertTrue(result.getOutput().contains("-exclude"))
-        
+
         def filterPath = Paths.get(System.getProperty("java.io.tmpdir"), "spotBugs-excludeFilter.xml").toString()
         def partialFilterPath = filterPath.replace('.xml','')
-        
+
         assertTrue(result.getOutput().contains(partialFilterPath))
     }
 

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -89,7 +89,7 @@ class SpotBugsExtension {
      */
     @NonNull
     final DirectoryProperty reportsDir;
-    
+
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -100,7 +100,7 @@ class SpotBugsExtension {
      */
     @NonNull
     final Property<Object> includeFilter;
-    
+
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -111,7 +111,7 @@ class SpotBugsExtension {
      */
     @NonNull
     final Property<Object> excludeFilter;
-    
+
     /**
      * Property to specify the target classes for analysis. Default value is empty that means all classes are analyzed.
      */

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -40,8 +40,8 @@ import org.gradle.api.provider.Property;
  * &nbsp;&nbsp;&nbsp;&nbsp;visitors = [ 'FindSqlInjection', 'SwitchFallthrough' ]<br>
  * &nbsp;&nbsp;&nbsp;&nbsp;omitVisitors = [ 'FindNonShortCircuit' ]<br>
  * &nbsp;&nbsp;&nbsp;&nbsp;reportsDir = file("$buildDir/reports/spotbugs")<br>
- * &nbsp;&nbsp;&nbsp;&nbsp;includeFilter = file('spotbugs-include.xml')<br>
- * &nbsp;&nbsp;&nbsp;&nbsp;excludeFilter = file('spotbugs-exclude.xml')<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;includeFilter = file('spotbugs-include.xml') or new URL('http://sonar?findbugs-include.xml')<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;excludeFilter = file('spotbugs-exclude.xml') or new URL('http://sonar?findbugs-exclude.xml')<br>
  * &nbsp;&nbsp;&nbsp;&nbsp;onlyAnalyze = ['com.foobar.MyClass', 'com.foobar.mypkg.*']<br>
  * &nbsp;&nbsp;&nbsp;&nbsp;projectName = name<br>
  * &nbsp;&nbsp;&nbsp;&nbsp;release = version<br>
@@ -89,6 +89,7 @@ class SpotBugsExtension {
      */
     @NonNull
     final DirectoryProperty reportsDir;
+    
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -98,7 +99,8 @@ class SpotBugsExtension {
      * <p>See also <a href="https://spotbugs.readthedocs.io/en/stable/filter.html">SpotBugs Manual about Filter file</a>.</p>
      */
     @NonNull
-    final RegularFileProperty includeFilter;
+    final Property<Object> includeFilter;
+    
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -108,7 +110,8 @@ class SpotBugsExtension {
      * <p>See also <a href="https://spotbugs.readthedocs.io/en/stable/filter.html">SpotBugs Manual about Filter file</a>.</p>
      */
     @NonNull
-    final RegularFileProperty excludeFilter;
+    final Property<Object> excludeFilter;
+    
     /**
      * Property to specify the target classes for analysis. Default value is empty that means all classes are analyzed.
      */
@@ -156,8 +159,8 @@ class SpotBugsExtension {
         visitors = objects.listProperty(String);
         omitVisitors = objects.listProperty(String);
         reportsDir = objects.directoryProperty()
-        includeFilter = objects.fileProperty()
-        excludeFilter = objects.fileProperty()
+        includeFilter = objects.property(Object)
+        excludeFilter = objects.property(Object)
         onlyAnalyze = objects.listProperty(String);
         projectName = objects.property(String);
         release = objects.property(String);

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -139,7 +139,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Internal
     @NonNull
     final NamedDomainObjectContainer<SpotBugsReport> reports;
-    
+
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -156,7 +156,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Internal
     @NonNull
     final RegularFileProperty includeFilterFile;
-    
+
     /**
      * Property to set the filter file to limit which bug should be reported.
      *
@@ -169,11 +169,11 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Input
     @NonNull
     final Property<Object> excludeFilter;
-    
+
     @Internal
     @NonNull
     final RegularFileProperty excludeFilterFile;
-    
+
     /**
      * Property to specify the target classes for analysis. Default value is empty that means all classes are analyzed.
      */

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -342,8 +342,6 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         useAuxclasspathFile.convention(extension.useAuxclasspathFile)
     }
 
-    
-
     @TaskAction
     void run() {
         if (getProject().hasProperty(FEATURE_FLAG_WORKER_API)
@@ -431,23 +429,23 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         }
         return new StringBuilder().append(Character.toLowerCase(prunedName.charAt(0))).append(prunedName.substring(1)).toString()
     }
-    
+
     private processFilterFile(Property<Object> filterProperty,
             RegularFileProperty filterFileProperty, String filterName) {
         if (filterProperty.isPresent()) {
             def filter = filterProperty.get()
-    
+
             if (filter instanceof File) {
                 filterFileProperty.set(filter)
             }
             else if (filter instanceof URL) {
                 def tempFile = File.createTempFile("spotBugs-$filterName", ".xml")
                 tempFile.deleteOnExit()
-    
+
                 tempFile.withOutputStream { out ->
                     out << filter.openStream()
                 }
-    
+
                 filterFileProperty.set(tempFile)
             }
             else {

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -51,7 +51,7 @@ public abstract class SpotBugsRunner {
     args.add("-sortByClass");
     args.add("-timestampNow");
     if (!task.getAuxClassPaths().isEmpty()) {
-      if (task.getUseAuxclasspathFile().get()) {
+      if (Boolean.TRUE.equals(task.getUseAuxclasspathFile().get())) {
         args.add("-auxclasspathFromFile");
         String auxClasspathFile = createFileForAuxClasspath(task);
         log.debug("Using auxclasspath file: {}", auxClasspathFile);
@@ -92,13 +92,13 @@ public abstract class SpotBugsRunner {
       args.add("-omitVisitors");
       args.add(task.getOmitVisitors().get().stream().collect(Collectors.joining(",")));
     }
-    if (task.getIncludeFilter().isPresent() && task.getIncludeFilter().get() != null) {
+    if (task.getIncludeFilterFile().isPresent() && task.getIncludeFilterFile().get() != null) {
       args.add("-include");
-      args.add(task.getIncludeFilter().get().getAsFile().getAbsolutePath());
+      args.add(task.getIncludeFilterFile().get().getAsFile().getAbsolutePath());
     }
-    if (task.getExcludeFilter().isPresent() && task.getExcludeFilter().get() != null) {
+    if (task.getExcludeFilterFile().isPresent() && task.getExcludeFilterFile().get() != null) {
       args.add("-exclude");
-      args.add(task.getExcludeFilter().get().getAsFile().getAbsolutePath());
+      args.add(task.getExcludeFilterFile().get().getAsFile().getAbsolutePath());
     }
     if (task.getOnlyAnalyze().isPresent() && !task.getOnlyAnalyze().get().isEmpty()) {
       args.add("-onlyAnalyze");


### PR DESCRIPTION
Use Property so that the either URL or File can be given. If the URL is given then the rules file is downloaded to the temp location first and plugin uses it from there. Also added two functional tests to cover the new use cases.