### PR TITLE
Stop printing null if no report is available

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/BasePluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/BasePluginFunctionalTest.groovy
@@ -141,7 +141,7 @@ task spotbugsMain(type: com.github.spotbugs.snom.SpotBugsTask) {
 """
         when:
         def arguments = [':spotbugsMain']
-        if(!isWorkerApi) {
+        if (!isWorkerApi) {
             arguments.add('-Pcom.github.spotbugs.snom.worker=false')
         }
         def runner = GradleRunner.create()
@@ -159,6 +159,7 @@ task spotbugsMain(type: com.github.spotbugs.snom.SpotBugsTask) {
         !result.output.contains('SpotBugs report can be found in null')
 
         where:
+        // Each SpotBugsRunner has code to handle report, so test both SpotBugsRunnerForWorker and SpotBugsRunnerForJavaExec
         isWorkerApi << [true, false]
     }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -18,6 +18,7 @@ import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs;
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.TextUICommandLine;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
@@ -94,14 +95,14 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
             throw new GradleException(
                 "Verification failed: SpotBugs error found: "
                     + findBugs2.getErrorCount()
-                    + ". SpotBugs report can be found in "
-                    + findReportPath());
+                    + ". "
+                    + buildMessageAboutReport());
           } else if (findBugs2.getBugCount() > 0) {
             throw new GradleException(
                 "Verification failed: SpotBugs violation found: "
                     + findBugs2.getBugCount()
-                    + ". SpotBugs report can be found in "
-                    + findReportPath());
+                    + ". "
+                    + buildMessageAboutReport());
           }
         }
       } catch (GradleException e) {
@@ -115,6 +116,16 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
       }
     }
 
+    private String buildMessageAboutReport() {
+      String reportPath = findReportPath();
+      if (reportPath != null) {
+        return "SpotBugs report can be found in " + reportPath;
+      } else {
+        return "";
+      }
+    }
+
+    @CheckForNull
     private String findReportPath() {
       List<String> arguments = getParameters().getArguments().get();
       int outputFileParameterIndex = arguments.indexOf("-outputFile");


### PR DESCRIPTION
When user uses the `base` plugin, it's possible to have no reporting so `findReportPath()` returns `null`. This PR will fix this behavior, by simply skipping the report path.