### PR TITLE
sign gradle plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
+      env:
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
       run: ./gradlew build --no-daemon -Dsnom.test.functional.gradle=${{ matrix.gradle }}
     - name: Run Semantic Release
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -309,6 +309,7 @@ $RECYCLE.BIN/
 ### Gradle ###
 .gradle
 build/
+gradle.properties
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ dependencies {
 }
 ```
 
+## Development
+Since version 4.3, when we publish artifacts we now sign them. 
+
+Before github workflow can sign the artifacts generated during build, we first need to generate pgp keys (you will have to do this again when the key expires. once a year is a good timeframe) and upload them to the servers. See https://www.gnupg.org/faq/gnupg-faq.html#starting_out for more details.
+
+That means github needs the following secrets:
+```
+secrets.SIGNING_KEY_ID = A85D790D
+secrets.SIGNING_PASSWORD = password
+```
+where `secrets.SIGNING_KEY_ID` is the last 8 characters of your generated ID
+and `secrets.SIGNING_PASSWORD` is the password you used when generating the key.
+
+Gradle is configured to use these to generate the private key in memory so as to minimize our
+
 ## Copyright
 
 Copyright &copy; 2019-present SpotBugs Team

--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ Before github workflow can sign the artifacts generated during build, we first n
 
 That means github needs the following secrets:
 ```
-secrets.SIGNING_KEY_ID = A85D790D
-secrets.SIGNING_PASSWORD = password
+SIGNING_KEY = "-----BEGIN PGP PRIVATE KEY BLOCK-----..."
+SIGNING_PASSWORD = password
 ```
-where `secrets.SIGNING_KEY_ID` is the last 8 characters of your generated ID
+where `secrets.SIGNING_KEY` is the in-memory ascii-armored keys (you get this by running `gpg --armor --export-secret-keys <EMAIL>`)
 and `secrets.SIGNING_PASSWORD` is the password you used when generating the key.
 
-Gradle is configured to use these to generate the private key in memory so as to minimize our
+Gradle is configured to use these to generate the private key in memory so as to minimize our risk of the keys being found and used by someone else.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ dependencies {
 ```
 
 ## Development
-Since version 4.3, when we publish artifacts we now sign them. 
+Since version 4.3, when we publish artifacts we now sign them. This is designed so that the build will still pass if you don't have the signing keys available, this way pull requests and forked repos will still work as before.
 
 Before github workflow can sign the artifacts generated during build, we first need to generate pgp keys (you will have to do this again when the key expires. once a year is a good timeframe) and upload them to the servers. See https://www.gnupg.org/faq/gnupg-faq.html#starting_out for more details.
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,6 @@ plugins {
     id 'se.patrikerdes.use-latest-versions' version '0.2.13'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'org.sonarqube' version '2.8'
-    
-    id "com.dorongold.task-tree" version "1.5"
 }
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ groovydoc {
 }
 
 signing {
-    def signingKey = findProperty("secrets.SIGNING_KEY_ID")
-    def signingPassword = findProperty("secrets.SIGNING_PASSWORD")
+    def signingKey = findProperty("SIGNING_KEY")
+    def signingPassword = findProperty("SIGNING_PASSWORD")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign configurations.archives
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ groovydoc {
 }
 
 signing {
-    def signingKey = findProperty("SIGNING_KEY")
-    def signingPassword = findProperty("SIGNING_PASSWORD")
+    def signingKey = System.getenv("SIGNING_KEY")
+    def signingPassword = System.getenv("SIGNING_PASSWORD")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign configurations.archives
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ if(signingKey != null && signingPassword != null){
 }
 else{
   logger.warn('The signing key and password are null. This can be ignored if this is a pull request.')
+  signArchives.enabled = false
 }
 
 task processVersionFile(type: WriteProperties) {

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,17 @@ groovydoc {
     link 'https://docs.groovy-lang.org/latest/html/gapi/', 'groovy.', 'org.codehaus.groovy.'
 }
 
-signing {
-    def signingKey = System.getenv("SIGNING_KEY")
-    def signingPassword = System.getenv("SIGNING_PASSWORD")
+def signingKey = System.getenv("SIGNING_KEY")
+def signingPassword = System.getenv("SIGNING_PASSWORD")
+
+if(signingKey != null && signingPassword != null){
+  signing {
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign configurations.archives
+  }
+}
+else{
+  logger.warn('The signing key and password are null. This can be ignored if this is a pull request.')
 }
 
 task processVersionFile(type: WriteProperties) {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ groovydoc {
 def signingKey = System.getenv("SIGNING_KEY")
 def signingPassword = System.getenv("SIGNING_PASSWORD")
 
+signArchives.onlyIf { signingKey != null && signingPassword != null }
+
 if(signingKey != null && signingPassword != null){
   signing {
     useInMemoryPgpKeys(signingKey, signingPassword)
@@ -55,7 +57,6 @@ if(signingKey != null && signingPassword != null){
 }
 else{
   logger.warn('The signing key and password are null. This can be ignored if this is a pull request.')
-  signArchives.enabled = false
 }
 
 task processVersionFile(type: WriteProperties) {

--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,8 @@ groovydoc {
     link 'https://docs.groovy-lang.org/latest/html/gapi/', 'groovy.', 'org.codehaus.groovy.'
 }
 
-//def signingKey = System.getenv("SIGNING_KEY")
-def signingKey = ""
-//def signingPassword = System.getenv("SIGNING_PASSWORD")
-def signingPassword = ""
+def signingKey = System.getenv("SIGNING_KEY")
+def signingPassword = System.getenv("SIGNING_PASSWORD")
 
 signing {
     if(signingKey != null &&

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,15 @@ plugins {
     id 'groovy'
     id 'java-gradle-plugin'
     id 'jacoco'
+    id 'signing'
     id 'com.gradle.plugin-publish' version '0.11.0'
     id 'com.diffplug.gradle.spotless' version '4.0.0'
     id 'net.ltgt.errorprone' version '1.1.1'
     id 'se.patrikerdes.use-latest-versions' version '0.2.13'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'org.sonarqube' version '2.8'
+    
+    id "com.dorongold.task-tree" version "1.5"
 }
 
 sourceCompatibility = 1.8
@@ -41,6 +44,13 @@ groovydoc {
     link 'https://docs.gradle.org/current/javadoc/', 'org.gradle.api.'
     link 'https://docs.oracle.com/en/java/javase/11/docs/api/', 'java.'
     link 'https://docs.groovy-lang.org/latest/html/gapi/', 'groovy.', 'org.codehaus.groovy.'
+}
+
+signing {
+    def signingKey = findProperty("secrets.SIGNING_KEY_ID")
+    def signingPassword = findProperty("secrets.SIGNING_PASSWORD")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign configurations.archives
 }
 
 task processVersionFile(type: WriteProperties) {

--- a/build.gradle
+++ b/build.gradle
@@ -47,17 +47,17 @@ groovydoc {
 def signingKey = System.getenv("SIGNING_KEY")
 def signingPassword = System.getenv("SIGNING_PASSWORD")
 
-signArchives.onlyIf { signingKey != null && signingPassword != null }
+signing {
+    if(signingKey != null && signingPassword != null){
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign configurations.archives
+    }
+    else{
+        logger.warn('The signing key and password are null. This can be ignored if this is a pull request.')
+    }
+}
 
-if(signingKey != null && signingPassword != null){
-  signing {
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign configurations.archives
-  }
-}
-else{
-  logger.warn('The signing key and password are null. This can be ignored if this is a pull request.')
-}
+
 
 task processVersionFile(type: WriteProperties) {
     outputFile file('src/main/resources/spotbugs-gradle-plugin.properties')

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,16 @@ groovydoc {
     link 'https://docs.groovy-lang.org/latest/html/gapi/', 'groovy.', 'org.codehaus.groovy.'
 }
 
-def signingKey = System.getenv("SIGNING_KEY")
-def signingPassword = System.getenv("SIGNING_PASSWORD")
+//def signingKey = System.getenv("SIGNING_KEY")
+def signingKey = ""
+//def signingPassword = System.getenv("SIGNING_PASSWORD")
+def signingPassword = ""
 
 signing {
-    if(signingKey != null && signingPassword != null){
+    if(signingKey != null &&
+    signingPassword != null &&
+    !signingKey.isEmpty() &&
+    !signingPassword.isEmpty()){
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign configurations.archives
     }


### PR DESCRIPTION
This pull request closes #192 - plugin not signed. Note that some additional work needs to be done by the maintainer, mainly generating the PGP keys, uploading them to the pool servers, and adding the secrets to the github repository. See README for instructions.