### PR TITLE
fix: create auxclasspath file for each spotbugs task

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -477,7 +477,6 @@ public class MyFoo {
 }
 """
 
-
         when:
         BuildResult result =
                 GradleRunner.create()
@@ -492,6 +491,19 @@ public class MyFoo {
         result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
         result.output.contains("Using auxclasspath file")
         result.output.contains("/build/spotbugs/auxclasspath/spotbugsMain")
+
+        when:
+        BuildResult repeatedResult =
+                GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments("spotbugsMain", '--rerun-tasks', '-s')
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+                .build()
+
+        then:
+        repeatedResult.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
     }
 
     def "can apply plugin using useAuxclasspathFile flag in parallel"() {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -491,7 +491,68 @@ public class MyFoo {
         then:
         result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
         result.output.contains("Using auxclasspath file")
-        result.output.contains("/build/spotbugs/spotbugs-auxclasspath")
+        result.output.contains("/build/spotbugs/spotbugs-auxclasspath-for-spotbugsMain")
+    }
+
+    def "can apply plugin using useAuxclasspathFile flag in parallel"() {
+        given:
+        buildFile << """
+spotbugs {
+  useAuxclasspathFile = true
+}
+dependencies {
+  implementation 'com.google.guava:guava:19.0'
+  testImplementation 'junit:junit:4.12'
+}"""
+
+        File sourceDir = rootDir.toPath().resolve(Paths.get("src", "main", "java")).toFile()
+        sourceDir.mkdirs()
+        File sourceFile = new File(sourceDir, "MyFoo.java")
+        sourceFile << """
+public class MyFoo {
+    public static void main(String... args) {
+        java.util.Map items = com.google.common.collect.ImmutableMap.of("coin", 3, "glass", 4, "pencil", 1);
+                
+                        items.entrySet()
+                                .stream()
+                                .forEach(System.out::println);
+    }
+}
+"""
+
+        File testSourceDir = rootDir.toPath().resolve(Paths.get("src", "test", "java")).toFile()
+        testSourceDir.mkdirs()
+        File testSourceFile = new File(testSourceDir, "SimpleTest.java")
+        testSourceFile << """
+import org.junit.*;
+import static org.junit.Assert.*;
+ 
+import java.util.*;
+ 
+public class SimpleTest {
+    @Test
+    public void testEmptyCollection() {
+        Collection collection = new ArrayList();
+        assertTrue(collection.isEmpty());
+    }
+}
+"""
+
+        when:
+        BuildResult result =
+                GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments("spotbugsMain", "spotbugsTest", '--parallel', '--debug')
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+                .build()
+
+        then:
+        result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
+        result.output.contains("Using auxclasspath file")
+        result.output.contains("/build/spotbugs/spotbugs-auxclasspath-for-spotbugsMain")
+        result.output.contains("/build/spotbugs/spotbugs-auxclasspath-for-spotbugsTest")
     }
 
     @Unroll

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -491,7 +491,7 @@ public class MyFoo {
         then:
         result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
         result.output.contains("Using auxclasspath file")
-        result.output.contains("/build/spotbugs/spotbugs-auxclasspath-for-spotbugsMain")
+        result.output.contains("/build/spotbugs/auxclasspath/spotbugsMain")
     }
 
     def "can apply plugin using useAuxclasspathFile flag in parallel"() {
@@ -551,8 +551,8 @@ public class SimpleTest {
         then:
         result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
         result.output.contains("Using auxclasspath file")
-        result.output.contains("/build/spotbugs/spotbugs-auxclasspath-for-spotbugsMain")
-        result.output.contains("/build/spotbugs/spotbugs-auxclasspath-for-spotbugsTest")
+        result.output.contains("/build/spotbugs/auxclasspath/spotbugsMain")
+        result.output.contains("/build/spotbugs/auxclasspath/spotbugsTest")
     }
 
     @Unroll

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -128,13 +128,22 @@ public abstract class SpotBugsRunner {
               task.getProject().getBuildDir().getAbsolutePath(),
               "spotbugs",
               "spotbugs-auxclasspath-for-" + task.getName());
-      Files.createDirectories(auxClasspathFile.getParent());
-      Files.createFile(auxClasspathFile);
-      Files.write(auxClasspathFile, auxClasspath.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
-      return auxClasspathFile.normalize().toString();
+      try {
+        Files.createDirectories(auxClasspathFile.getParent());
+        if (Files.exists(auxClasspathFile)) {
+          Files.delete(auxClasspathFile);
+        }
+        Files.createFile(auxClasspathFile);
+        Files.write(auxClasspathFile, auxClasspath.getBytes(), StandardOpenOption.WRITE);
+        return auxClasspathFile.normalize().toString();
+      } catch (Exception e) {
+        throw new GradleException(
+            "Could not create auxiliary classpath file for SpotBugsTask at "
+                + auxClasspathFile.normalize().toString(),
+            e);
+      }
     } catch (Exception e) {
-      // oops
-      throw new GradleException("Could not create auxiliary classpath file for SpotBugsTask");
+      throw new GradleException("Could not create auxiliary classpath file for SpotBugsTask", e);
     }
   }
 

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -127,7 +127,7 @@ public abstract class SpotBugsRunner {
           Paths.get(
               task.getProject().getBuildDir().getAbsolutePath(),
               "spotbugs",
-              "spotbugs-auxclasspath");
+              "spotbugs-auxclasspath-for-" + task.getName());
       Files.createDirectories(auxClasspathFile.getParent());
       Files.createFile(auxClasspathFile);
       Files.write(auxClasspathFile, auxClasspath.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -131,11 +131,11 @@ public abstract class SpotBugsRunner {
               task.getName());
       try {
         Files.createDirectories(auxClasspathFile.getParent());
-        if (Files.exists(auxClasspathFile)) {
-          Files.delete(auxClasspathFile);
+        if (!Files.exists(auxClasspathFile)) {
+          Files.createFile(auxClasspathFile);
         }
-        Files.createFile(auxClasspathFile);
-        Files.write(auxClasspathFile, auxClasspath.getBytes(), StandardOpenOption.WRITE);
+        Files.write(
+            auxClasspathFile, auxClasspath.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
         return auxClasspathFile.normalize().toString();
       } catch (Exception e) {
         throw new GradleException(

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -127,7 +127,8 @@ public abstract class SpotBugsRunner {
           Paths.get(
               task.getProject().getBuildDir().getAbsolutePath(),
               "spotbugs",
-              "spotbugs-auxclasspath-for-" + task.getName());
+              "auxclasspath",
+              task.getName());
       try {
         Files.createDirectories(auxClasspathFile.getParent());
         if (Files.exists(auxClasspathFile)) {


### PR DESCRIPTION
and auxclasspath file is removed and created instead of truncated in place

This addresses #259 by avoiding re-creating the same file in any invocation, and adds some additional information if a failure occurs. 