### PR TITLE
using File.separator so that paths are OS independent

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -490,7 +490,8 @@ public class MyFoo {
         then:
         result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
         result.output.contains("Using auxclasspath file")
-        result.output.contains("/build/spotbugs/auxclasspath/spotbugsMain")
+        def expectedOutput = File.separator + "build" + File.separator + "spotbugs" + File.separator + "auxclasspath" + File.separator + "spotbugsMain"
+        result.output.contains(expectedOutput)
 
         when:
         BuildResult repeatedResult =
@@ -563,8 +564,10 @@ public class SimpleTest {
         then:
         result.task(":spotbugsMain").outcome == TaskOutcome.SUCCESS
         result.output.contains("Using auxclasspath file")
-        result.output.contains("/build/spotbugs/auxclasspath/spotbugsMain")
-        result.output.contains("/build/spotbugs/auxclasspath/spotbugsTest")
+        def expectedOutputMain = File.separator + "build" + File.separator + "spotbugs" + File.separator + "auxclasspath" + File.separator + "spotbugsMain"
+        result.output.contains(expectedOutputMain)
+        def expectedOutputTest = File.separator + "build" + File.separator + "spotbugs" + File.separator + "auxclasspath" + File.separator + "spotbugsTest"
+        result.output.contains(expectedOutputTest)
     }
 
     @Unroll
@@ -595,7 +598,8 @@ public class SimpleTest {
         then:
         result.task(':spotbugsMain').outcome == TaskOutcome.FAILED
         result.output.contains('SpotBugs report can be found in')
-        result.output.contains('build/reports/spotbugs/main.xml')
+        def expectedOutput = File.separator + "build" + File.separator + "reports" + File.separator + "spotbugs" + File.separator + "main.xml"
+        result.output.contains(expectedOutput)
 
         where:
         isWorkerApi << [true, false]


### PR DESCRIPTION
fixes #273 because some of the paths were using `/` while windows uses `\` for the path separator. Now use File.separator which will automatically choose the correct one based on which OS you are using.