### PR TITLE
always print message about failure and report location

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -115,7 +115,7 @@ buildDir = 'new-build-dir'
         File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main.txt").toFile()
         assertTrue(report.isFile())
     }
-    
+
     def "prints reports location when stacktrace is suppressed"() {
         buildFile << """
 spotbugsMain {
@@ -133,7 +133,7 @@ buildDir = 'new-build-dir'
         |  public int unreadField = 42; // warning: URF_UNREAD_FIELD
         |}
         |'''.stripMargin()
-        
+
         when:
         def result = GradleRunner.create()
                 .withProjectDir(rootDir)

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -115,10 +115,41 @@ buildDir = 'new-build-dir'
         File report = rootDir.toPath().resolve("new-build-dir").resolve("reports").resolve("spotbugs").resolve("main.txt").toFile()
         assertTrue(report.isFile())
     }
+    
+    def "prints reports location when stacktrace is suppressed"() {
+        buildFile << """
+spotbugsMain {
+    showStackTraces = false
+    reports {
+        text.enabled = true
+    }
+}
+buildDir = 'new-build-dir'
+"""
+        given:
+        def badCode = new File(rootDir, 'src/main/java/Bar.java')
+        badCode << '''
+        |public class Bar {
+        |  public int unreadField = 42; // warning: URF_UNREAD_FIELD
+        |}
+        |'''.stripMargin()
+        
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments('spotbugsMain')
+                .withPluginClasspath()
+                .buildAndFail()
+
+        then:
+        //issue 284 - information on where the report should still be printed even if suppressing stack traces.
+        result.output.contains('SpotBugs report can be found in')
+    }
 
     def "can generate spotbugs.html in configured buildDir"() {
         buildFile << """
 spotbugsMain {
+    showStackTraces = false
     reports {
         html.enabled = true
     }

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -289,6 +289,7 @@ spotbugs {
         then:
         result.task(':spotbugsMain').outcome == TaskOutcome.SUCCESS
         !(result.output.contains('\tat '))
+        result.output.contains('SpotBugs report can be found in')
 
         where:
         isWorkerApi << [true, false]

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -289,7 +289,6 @@ spotbugs {
         then:
         result.task(':spotbugsMain').outcome == TaskOutcome.SUCCESS
         !(result.output.contains('\tat '))
-        result.output.contains('SpotBugs report can be found in')
 
         where:
         isWorkerApi << [true, false]

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -112,7 +112,7 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
         if (params.getIgnoreFailures().getOrElse(Boolean.FALSE).booleanValue()) {
           final boolean showStackTraces =
               params.getShowStackTraces().getOrElse(Boolean.TRUE).booleanValue();
-          log.warn("SpotBugs reported failures", showStackTraces ? e : null);
+          log.warn("SpotBugs reported failures", showStackTraces ? e : e.getMessage());
         } else {
           throw e;
         }


### PR DESCRIPTION
this fixes #284 - when suppressing stack trace still print message about where report is and what caused the error.