### PR TITLE
fix: Print report location as file uri and improve warning messages

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -143,7 +143,7 @@ buildDir = 'new-build-dir'
 
         then:
         //issue 284 - information on where the report should still be printed even if suppressing stack traces.
-        result.output.contains('SpotBugs report can be found in')
+        result.output.contains('See the report at')
     }
 
     def "can generate spotbugs.html in configured buildDir"() {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -635,7 +635,7 @@ public class SimpleTest {
 
         then:
         result.task(':spotbugsMain').outcome == TaskOutcome.FAILED
-        result.output.contains('SpotBugs report can be found in')
+        result.output.contains('See the report at')
         def expectedOutput = File.separator + "build" + File.separator + "reports" + File.separator + "spotbugs" + File.separator + "main.xml"
         result.output.contains(expectedOutput)
 

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
@@ -16,6 +16,8 @@ package com.github.spotbugs.snom.internal;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,10 +43,12 @@ public class SpotBugsRunnerForJavaExec extends SpotBugsRunner {
         String errorMessage = "Verification failed: SpotBugs execution thrown exception.";
         List<String> reportPaths =
             task.getReportsDir().getAsFileTree().getFiles().stream()
-                .map(File::getAbsolutePath)
+                .map(File::toPath)
+                .map(Path::toUri)
+                .map(URI::toString)
                 .collect(Collectors.toList());
         if (!reportPaths.isEmpty()) {
-          errorMessage += "SpotBugs report can be found in " + String.join(",", reportPaths);
+          errorMessage += "See the report at: " + String.join(",", reportPaths);
         }
         throw new GradleException(errorMessage, e);
       }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.TextUICommandLine;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import org.gradle.api.Action;
@@ -96,15 +97,13 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
           findBugs2.execute();
           if (findBugs2.getErrorCount() > 0) {
             throw new GradleException(
-                "Verification failed: SpotBugs error found: "
-                    + findBugs2.getErrorCount()
-                    + ". "
+                findBugs2.getErrorCount()
+                    + " SpotBugs errors were found. "
                     + buildMessageAboutReport());
           } else if (findBugs2.getBugCount() > 0) {
             throw new GradleException(
-                "Verification failed: SpotBugs violation found: "
-                    + findBugs2.getBugCount()
-                    + ". "
+                findBugs2.getBugCount()
+                    + " SpotBugs violations were found. "
                     + buildMessageAboutReport());
           }
         }
@@ -112,7 +111,7 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
         if (params.getIgnoreFailures().getOrElse(Boolean.FALSE).booleanValue()) {
           final boolean showStackTraces =
               params.getShowStackTraces().getOrElse(Boolean.TRUE).booleanValue();
-          log.warn("SpotBugs reported failures", showStackTraces ? e : e.getMessage());
+          log.warn(e.getMessage(), showStackTraces ? e : null);
         } else {
           throw e;
         }
@@ -124,7 +123,7 @@ public class SpotBugsRunnerForWorker extends SpotBugsRunner {
     private String buildMessageAboutReport() {
       String reportPath = findReportPath();
       if (reportPath != null) {
-        return "SpotBugs report can be found in " + reportPath;
+        return "See the report at: " + Paths.get(reportPath).toUri();
       } else {
         return "";
       }


### PR DESCRIPTION
* warning messages are now consistent with those reported by other native Gradle static code analysis tools (PMD, Checkstyle, etc...).
* fixes https://github.com/spotbugs/spotbugs-gradle-plugin/issues/286