### PR TITLE
Bump up the default toolVersion to 4.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
+| 4.4.2| 4.0.5|
 | 4.0.7| 4.0.2|
 | 4.0.0| 4.0.0|
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.3.4'
-    spotBugsVersion = '4.0.2'
+    spotBugsVersion = '4.0.5'
     slf4jVersion = '1.8.0-beta4'
     androidGradlePluginVersion = '4.0.0'
 }


### PR DESCRIPTION
This change will release the next patch version 4.4.2, to bump up the default `toolVersion` to [the latest spotbugs 4.0.5](https://github.com/spotbugs/spotbugs/releases/tag/4.0.5).
