### PR TITLE
fix: bump up the default toolVersion to 4.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
+| 4.4.4| 4.0.6|
 | 4.4.2| 4.0.5|
 | 4.0.7| 4.0.2|
 | 4.0.0| 4.0.0|

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.3.4'
-    spotBugsVersion = '4.0.5'
+    spotBugsVersion = '4.0.6'
     slf4jVersion = '1.8.0-beta4'
     androidGradlePluginVersion = '4.0.0'
 }


### PR DESCRIPTION
4.0.5 has a critical issue around BCEL usage, so bump up the default `toolVersion` to the fixed version.