### PR TITLE
fix: Use `Classpath` normalization for `auxClassPaths`

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -36,6 +36,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
@@ -235,7 +236,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
      * Default value is the compile-scope dependencies of the target sourceSet.
      */
     @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     FileCollection auxClassPaths;
 
     /**


### PR DESCRIPTION
Declaring `auxClassPaths` as a `Classpath` property allows Gradle to perform additional normalization,
so that functionally-identical jar files do not trigger a re-execution of the SpotBugsTask. 

A re-generated jar containing identical classes will have different entry timestamps for each class entry,
and as such is not bitwise identical even though it is functionally identical.
Without this fix, changing an input jar file will change the input cache key, leading to consistent misses from the local build cache. 

See https://docs.gradle.org/6.0/userguide/more_about_tasks.html#sec:task_input_using_classpath_annotations

Note that I have tested this change locally, but not added any specific test coverage for this use case.