### PR TITLE
fix: remove needless annotation

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -235,7 +235,6 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
      * Property to specify the aux class paths that contains the libraries to refer during analysis.
      * Default value is the compile-scope dependencies of the target sourceSet.
      */
-    @InputFiles
     @Classpath
     FileCollection auxClassPaths;
 


### PR DESCRIPTION
we don't support Gradle < 3.2, so the InputFiles annotation is needless 
for fields which is already annotated with the Classpath annotation.

refs https://github.com/spotbugs/spotbugs-gradle-plugin/pull/314#issuecomment-700773441