### PR TITLE
Build optimization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,6 @@ plugins {
     id 'org.sonarqube' version '3.1.1'
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 group = 'com.github.spotbugs.snom'
 
 repositories {
@@ -33,6 +31,10 @@ dependencies {
     compileOnly "com.github.spotbugs:spotbugs:${spotBugsVersion}"
     compileOnly "com.android.tools.build:gradle:${androidGradlePluginVersion}"
     testImplementation 'com.tngtech.archunit:archunit:0.16.0'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
 }
 
 groovydoc {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ tasks.withType(JavaCompile).configureEach {
     options.release = 8
 }
 
-groovydoc {
+tasks.named('groovydoc') {
     docTitle 'SpotBugs Gradle Plugin'
     link 'https://docs.gradle.org/current/javadoc/', 'org.gradle.api.'
     link 'https://docs.oracle.com/en/java/javase/11/docs/api/', 'java.'
@@ -60,15 +60,15 @@ signing {
     }
 }
 
-
-
-task processVersionFile(type: WriteProperties) {
+def processVersionFile = tasks.register('processVersionFile', WriteProperties) {
     outputFile file('src/main/resources/spotbugs-gradle-plugin.properties')
 
     property 'slf4j-version', slf4jVersion
     property 'spotbugs-version', spotBugsVersion
 }
-tasks.processResources.dependsOn processVersionFile
+tasks.named('processResources').configure {
+    dependsOn processVersionFile
+}
 
 apply from: "$rootDir/gradle/test.gradle"
 apply from: "$rootDir/gradle/functional-test.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.12.0'
     id 'com.diffplug.spotless' version '5.9.0'
     id 'net.ltgt.errorprone' version '1.3.0'
-    id 'se.patrikerdes.use-latest-versions' version '0.2.15'
-    id 'com.github.ben-manes.versions' version '0.36.0'
     id 'org.sonarqube' version '3.1.1'
 }
 

--- a/gradle/HEADER.txt
+++ b/gradle/HEADER.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -20,7 +20,7 @@ gradlePlugin {
     testSourceSets sourceSets.functionalTest
 }
 
-task functionalTest(type: Test) {
+def functionalTest = tasks.register('functionalTest', Test) {
     description = 'Runs the functional tests.'
     group = 'verification'
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
@@ -29,4 +29,6 @@ task functionalTest(type: Test) {
     systemProperty 'snom.test.functional.gradle', System.getProperty('snom.test.functional.gradle', gradle.gradleVersion)
 }
 
-check.dependsOn functionalTest
+tasks.named('check').configure {
+    dependsOn functionalTest
+}

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -32,7 +32,7 @@ sonarqube {
         property "sonar.projectKey", "com.github.spotbugs.gradle"
         property "sonar.organization", "spotbugs"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination
+        property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.map { it.reports.xml.destination }
     }
 }
 tasks.named('sonarqube').configure {

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -8,7 +8,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 }
 
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
     maxParallelForks = Runtime.runtime.availableProcessors()
 }
@@ -16,14 +16,16 @@ test {
 jacoco {
     toolVersion = "0.8.5"
 }
-jacocoTestReport {
+def jacocoTestReport = tasks.named('jacocoTestReport') {
     reports {
         xml {
             enabled true
         }
     }
 }
-tasks.check.dependsOn 'jacocoTestReport'
+tasks.named('check').configure {
+    dependsOn jacocoTestReport
+}
 
 sonarqube {
     properties {
@@ -33,4 +35,6 @@ sonarqube {
         property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination
     }
 }
-tasks.sonarqube.mustRunAfter jacocoTestReport
+tasks.named('sonarqube').configure {
+    mustRunAfter jacocoTestReport
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/AndroidFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/AndroidFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/BasePluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/BasePluginFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/Issue196.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/Issue196.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/MultiProjectFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/MultiProjectFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/Confidence.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/Confidence.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/Effort.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/Effort.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsHtmlReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsSarifReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsSarifReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTextReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsXmlReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/github/spotbugs/snom/SpotBugsPluginTest.java
+++ b/src/test/java/com/github/spotbugs/snom/SpotBugsPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SpotBugs team
+ * Copyright 2021 SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Optimize Gradle build script for performance.

I also found that Groovydoc reports error because it fails parsing lambda in `.java` files.
We can solve it by migrating `.java` to `.groovy`, I will handle it in another PR.