### PR TITLE
Bump up the default SpotBugs version to 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
+| 4.6.1| 4.2.1|
 | 4.5.0| 4.1.1|
 | 4.4.4| 4.0.6|
 | 4.4.2| 4.0.5|

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.5.1'
-    spotBugsVersion = '4.1.1'
+    spotBugsVersion = '4.2.1'
     slf4jVersion = '1.8.0-beta4'
     androidGradlePluginVersion = '4.1.2'
 }


### PR DESCRIPTION
This PR updates the default SpotBugs version to 4.2.1.

close #356 