### PR TITLE
fix: don't depend on jcenter for android dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,14 @@ group = 'com.github.spotbugs.snom'
 repositories {
     // To download the Android Gradle Plugin
     google()
-    // To download trove4j required by the Android Gradle Plugin
-    jcenter()
+    mavenCentral()
 }
 
 ext {
     errorproneVersion = '2.5.1'
     spotBugsVersion = '4.2.2'
     slf4jVersion = '1.8.0-beta4'
-    androidGradlePluginVersion = '4.1.2'
+    androidGradlePluginVersion = '7.0.0-alpha12'
 }
 
 dependencies {
@@ -33,6 +32,7 @@ dependencies {
     compileOnly localGroovy()
     compileOnly "com.github.spotbugs:spotbugs:${spotBugsVersion}"
     compileOnly "com.android.tools.build:gradle:${androidGradlePluginVersion}"
+	compileOnly "com.intellij:annotations:12.0"
     testImplementation 'com.tngtech.archunit:archunit:0.17.0'
 }
 


### PR DESCRIPTION
fixes #418. Currently in draft because android release is still in beta.