### PR TITLE
fix: Replace JCenter repository with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
     // To download the Android Gradle Plugin
     google()
     // To download trove4j required by the Android Gradle Plugin
-    jcenter()
+    mavenCentral()
 }
 
 ext {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/AndroidFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/AndroidFunctionalTest.groovy
@@ -158,7 +158,7 @@ class AndroidFunctionalTest extends Specification {
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -178,7 +178,7 @@ apply plugin: 'com.github.spotbugs'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 android {
@@ -199,7 +199,7 @@ android {
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -219,7 +219,7 @@ apply plugin: 'com.github.spotbugs'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 android {


### PR DESCRIPTION
The trove4j dependency has been republished to Maven Central:
https://search.maven.org/artifact/org.jetbrains.trove4j/trove4j/20160824/jar

Fixes #418