### PR TITLE
Fix groovydoc

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        cache: npm
     - uses: actions/cache@v2
       with:
         path: ~/.gradle/caches

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          cache: npm
       - name: Generate Groovydoc
         run: ./gradlew groovydoc
       - name: Prepare to Deploy

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The [latest groovydoc](https://spotbugs-gradle-plugin.netlify.app/com/github/spotbugs/snom/package-summary.html) contains strange Enum named `Confidence.1`. It also lacking description of classes and fields.