### PR TITLE
Release spotbugs-gradle-plugin v5

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gradle: ['5.6.4', '6.9', '7.0']
+        gradle: ['7.0', '7.1']
     steps:
     - uses: actions/checkout@v2
       with:
@@ -55,7 +55,7 @@ jobs:
         rm -rf build/libs/*.jar
         npm ci
         npx semantic-release
-      if: matrix.gradle == '6.9'
+      if: matrix.gradle == '7.0'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run SonarQube Scanner
@@ -63,7 +63,7 @@ jobs:
         if [ "$SONAR_LOGIN" != "" ]; then
           ./gradlew sonarqube -Dsonar.login=$SONAR_LOGIN --no-daemon
         fi
-      if: matrix.gradle == '6.9'
+      if: matrix.gradle == '7.0'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ to set task-specific properties.
 spotbugsMain {
     reports {
         html {
-            enabled = true
+            required = true
             destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
             stylesheet = 'fancy-hist.xsl'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ spotbugs {
 spotbugsMain {
     reports {
         sarif {
-            enabled = true
+            required = true
         }
     }
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -16,7 +16,7 @@ tasks.withType(Test).configureEach {
 def jacocoTestReport = tasks.named('jacocoTestReport') {
     reports {
         xml {
-            enabled true
+            required = true
         }
     }
 }

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -93,6 +93,11 @@ class CacheabilityFunctionalTest extends Specification {
             |repositories {
             |    mavenCentral()
             |}
+            |spotbugsMain {
+            |    reports {
+            |        text.required = true
+            |    }
+            |}
             |'''.stripMargin()
 
         File sourceDir = buildDir.toPath().resolve('src').resolve('main').resolve('java').toFile()

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/GradleJavaToolchainsSupportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/GradleJavaToolchainsSupportFunctionalTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 SpotBugs team
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.spotbugs.snom
+
+import org.gradle.internal.impldep.com.google.common.io.Files
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
+import org.junit.jupiter.api.BeforeEach
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GradleJavaToolchainsSupportFunctionalTest extends Specification {
+    File rootDir
+    File buildFile
+    String version = System.getProperty('snom.test.functional.gradle', GradleVersion.current().version)
+
+    @BeforeEach
+    def setup() {
+        rootDir = Files.createTempDir()
+        buildFile = new File(rootDir, 'build.gradle')
+        buildFile << """
+plugins {
+    id 'java'
+    id 'com.github.spotbugs'
+}
+
+version = 1.0
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(16)
+    }
+}
+        """
+        File sourceDir = rootDir.toPath().resolve("src").resolve("main").resolve("java").toFile()
+        sourceDir.mkdirs()
+        File sourceFile = new File(sourceDir, "Foo.java")
+        sourceFile << """
+public class Foo {
+    public static void main(String... args) {
+        System.out.println("Hello, SpotBugs!");
+    }
+}
+"""
+    }
+
+    @Unroll
+    def 'Supports Gradle Java Toolchains (#processConfiguration)'() {
+        setup:
+        buildFile << """
+        spotbugs {
+          useJavaToolchains = true
+        }"""
+
+        when:
+        def arguments = [':spotbugsMain', '-is']
+        arguments.add(processConfigurationArgument)
+
+        def runner = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+
+        def result = runner.build()
+
+        then:
+        result.task(':spotbugsMain').outcome == SUCCESS
+        result.output.contains('Spotbugs will be executed using Java Toolchain configuration')
+
+        where:
+        processConfiguration | processConfigurationArgument
+        'javaexec'           | '-Pcom.github.spotbugs.snom.worker=false'
+        'worker-api'         | '-Pcom.github.spotbugs.snom.worker=true'
+        'javaexec-in-worker' | '-Pcom.github.spotbugs.snom.javaexec-in-worker=true'
+    }
+
+    @Unroll
+    def 'Do not use Gradle Java Toolchains if extension is not configured (#processConfiguration)'() {
+        when:
+        def arguments = [':spotbugsMain', '-is']
+        arguments.add(processConfigurationArgument)
+
+        def runner = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+
+        def result = runner.build()
+
+        then:
+        result.task(':spotbugsMain').outcome == SUCCESS
+        !result.output.contains('Spotbugs will be executed using Java Toolchain configuration')
+
+
+        where:
+        processConfiguration | processConfigurationArgument
+        'javaexec'           | '-Pcom.github.spotbugs.snom.worker=false'
+        'worker-api'         | '-Pcom.github.spotbugs.snom.worker=true'
+        'javaexec-in-worker' | '-Pcom.github.spotbugs.snom.javaexec-in-worker=true'
+    }
+}

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -77,7 +77,7 @@ public class Foo {
         buildFile << """
 spotbugsMain {
     reports {
-        text.enabled = true
+        text.required = true
     }
 }"""
         when:
@@ -98,7 +98,7 @@ spotbugsMain {
         buildFile << """
 spotbugsMain {
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 buildDir = 'new-build-dir'
@@ -121,7 +121,7 @@ buildDir = 'new-build-dir'
 spotbugsMain {
     showStackTraces = false
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 buildDir = 'new-build-dir'
@@ -151,7 +151,7 @@ buildDir = 'new-build-dir'
 spotbugsMain {
     showStackTraces = false
     reports {
-        html.enabled = true
+        html.required = true
     }
 }
 buildDir = 'new-build-dir'
@@ -173,7 +173,7 @@ buildDir = 'new-build-dir'
         buildFile << """
 spotbugsMain {
     reports {
-        xml.enabled = true
+        xml.required = true
     }
 }
 buildDir = 'new-build-dir'
@@ -195,7 +195,7 @@ buildDir = 'new-build-dir'
         buildFile << """
 spotbugsMain {
     reports {
-        html.enabled = true
+        html.required = true
     }
 }"""
         when:
@@ -227,7 +227,7 @@ dependencies { spotbugsStylesheets 'com.github.spotbugs:spotbugs:3.1.10' }
 spotbugsMain {
     reports {
         html {
-            enabled = true
+            required = true
             stylesheet = resources.text.fromArchiveEntry(configurations.spotbugsStylesheets, 'fancy-hist.xsl')
         }
     }
@@ -257,7 +257,7 @@ spotbugsMain {
 spotbugsMain {
     reports {
         html {
-            enabled = true
+            required = true
             stylesheet = 'fancy-hist.xsl'
         }
     }
@@ -281,7 +281,7 @@ spotbugsMain {
         buildFile << """
 spotbugsMain {
     reports {
-        xml.enabled = true
+        xml.required = true
     }
 }"""
         when:
@@ -329,7 +329,7 @@ spotbugsMain {
         buildFile << """
 spotbugsMain {
     reports {
-        unknown.enabled = true
+        unknown.required = true
     }
 }"""
         when:
@@ -426,7 +426,7 @@ configurations.spotbugs {
         buildFile << """
 spotbugsMain {
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 reporting {
@@ -452,7 +452,7 @@ reporting {
         buildFile << """
 spotbugsMain {
     reports {
-        sarif.enabled = true
+        sarif.required = true
     }
 }"""
         when:

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -166,7 +166,7 @@ spotbugsMain {
         buildFile << """
 spotbugsMain {
     reports {
-        text.enabled = true
+        text.required = true
     }
 }"""
 
@@ -364,7 +364,7 @@ sourceSets {
 }
 spotbugsAnother {
     reports {
-        text.enabled = true
+        text.required = true
     }
 }"""
         File sourceDir = rootDir.toPath().resolve(Paths.get("src", "another", "java")).toFile()

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -615,6 +615,13 @@ public class SimpleTest {
     @Unroll
     def 'shows report path when failures are found (Worker API? #isWorkerApi)'() {
         given:
+        buildFile << """
+spotbugsMain {
+    reports {
+        xml.required = true
+    }
+}"""
+
         def badCode = new File(rootDir, 'src/main/java/Bar.java')
         badCode << '''
         |public class Bar {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -29,10 +29,10 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
   /**
    * Supported Gradle version described at <a
    * href="http://spotbugs.readthedocs.io/en/latest/gradle.html">official manual site</a>. <a
-   * href="https://guides.gradle.org/using-the-worker-api/">The Gradle Worker API</a> needs 5.6 or
-   * later, so we use this value as minimal required version.
+   * href="https://docs.gradle.org/current/userguide/toolchains.html">Toolchains for JVM
+   * projects</a> needs 7.0 or later, so we use this value as minimal required version.
    */
-  private static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("5.6");
+  private static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("7.0");
 
   @Override
   public void apply(Project project) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -156,6 +156,9 @@ class SpotBugsExtension {
     @NonNull
     final Property<Boolean> useAuxclasspathFile;
 
+    @NonNull
+    final Property<Boolean> useJavaToolchains
+
     @Inject
     SpotBugsExtension(Project project, ObjectFactory objects) {
         ignoreFailures = objects.property(Boolean).convention(false);
@@ -188,6 +191,7 @@ class SpotBugsExtension {
         maxHeapSize = objects.property(String);
         toolVersion = objects.property(String)
         useAuxclasspathFile = objects.property(Boolean).convention(false)
+        useJavaToolchains = objects.property(Boolean).convention(false)
     }
 
     void setReportLevel(@Nullable String name) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -406,15 +406,8 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Optional
     @Nested
     SpotBugsReport getFirstEnabledReport() {
-        // use XML report by default, only when SpotBugs plugin is applied
-        boolean isSpotBugsPluingApplied = project.pluginManager.hasPlugin("com.github.spotbugs")
-
         java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.required.getOrElse(report.enabled)}).findFirst()
-        if (isSpotBugsPluingApplied) {
-            return report.orElse(reports.create("xml"))
-        } else {
-            return report.orElse(null)
-        }
+        return report.orElse(null)
     }
 
     void setReportLevel(@Nullable String name) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -409,7 +409,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         // use XML report by default, only when SpotBugs plugin is applied
         boolean isSpotBugsPluingApplied = project.pluginManager.hasPlugin("com.github.spotbugs")
 
-        java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.enabled}).findFirst()
+        java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.required.getOrElse(report.enabled)}).findFirst()
         if (isSpotBugsPluingApplied) {
             return report.orElse(reports.create("xml"))
         } else {

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
@@ -30,6 +30,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.internal.ExecException;
@@ -50,9 +51,12 @@ import org.slf4j.LoggerFactory;
  */
 class SpotBugsRunnerForHybrid extends SpotBugsRunner {
   private final WorkerExecutor workerExecutor;
+  private final Property<JavaLauncher> javaLauncher;
 
-  public SpotBugsRunnerForHybrid(@NonNull WorkerExecutor workerExecutor) {
+  public SpotBugsRunnerForHybrid(
+      @NonNull WorkerExecutor workerExecutor, Property<JavaLauncher> javaLauncher) {
     this.workerExecutor = Objects.requireNonNull(workerExecutor);
+    this.javaLauncher = javaLauncher;
   }
 
   @Override
@@ -75,6 +79,11 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
       params.getIgnoreFailures().set(task.getIgnoreFailures());
       params.getShowStackTraces().set(task.getShowStackTraces());
       params.getReportsDir().set(task.getReportsDir());
+      if (javaLauncher.isPresent()) {
+        params
+            .getJavaToolchainExecutablePath()
+            .set(javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath());
+      }
     };
   }
 
@@ -92,6 +101,8 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
     Property<Boolean> getShowStackTraces();
 
     DirectoryProperty getReportsDir();
+
+    Property<String> getJavaToolchainExecutablePath();
   }
 
   public abstract static class SpotBugsExecutor implements WorkAction<SpotBugsWorkParameters> {
@@ -139,6 +150,12 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
         String maxHeapSize = params.getMaxHeapSize().getOrNull();
         if (maxHeapSize != null) {
           spec.setMaxHeapSize(maxHeapSize);
+        }
+        if (params.getJavaToolchainExecutablePath().isPresent()) {
+          log.info(
+              "Spotbugs will be executed using Java Toolchain configuration: {}",
+              params.getJavaToolchainExecutablePath().get());
+          spec.setExecutable(params.getJavaToolchainExecutablePath().get());
         }
       };
     }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
+import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.internal.ExecException;
 import org.slf4j.Logger;
@@ -30,6 +32,11 @@ import org.slf4j.LoggerFactory;
 
 public class SpotBugsRunnerForJavaExec extends SpotBugsRunner {
   private final Logger log = LoggerFactory.getLogger(SpotBugsRunnerForJavaExec.class);
+  private final Property<JavaLauncher> javaLauncher;
+
+  public SpotBugsRunnerForJavaExec(Property<JavaLauncher> javaLauncher) {
+    this.javaLauncher = javaLauncher;
+  }
 
   @Override
   public void run(@NonNull SpotBugsTask task) {
@@ -67,6 +74,13 @@ public class SpotBugsRunnerForJavaExec extends SpotBugsRunner {
       String maxHeapSize = task.getMaxHeapSize().getOrNull();
       if (maxHeapSize != null) {
         spec.setMaxHeapSize(maxHeapSize);
+      }
+      if (javaLauncher.isPresent()) {
+        log.info(
+            "Spotbugs will be executed using Java Toolchain configuration: Vendor: {} | Version: {}",
+            javaLauncher.get().getMetadata().getVendor(),
+            javaLauncher.get().getMetadata().getLanguageVersion().asInt());
+        spec.setExecutable(javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath());
       }
     };
   }

--- a/src/test/java/com/github/spotbugs/snom/SpotBugsPluginTest.java
+++ b/src/test/java/com/github/spotbugs/snom/SpotBugsPluginTest.java
@@ -36,9 +36,9 @@ class SpotBugsPluginTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("5.5"));
+          new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("6.7"));
         });
-    new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("5.6"));
+    new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("7.0"));
   }
 
   @Test


### PR DESCRIPTION
Release new features that introduce breaking changes:

1. Print report to the console by default
2. Support Gradle Toolchains for JVM projects that needs Gradle 7.0 or above
3. Prefer `Report#required` property over `Report#enabled` property that will [be removed from Gradle 8.0](https://docs.gradle.org/7.1.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled)

This PR is expected to release the version 5.0.0.

close #363
close #526