### PR TITLE
Update Workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: gradle
       - name: Gradle Wrapper Validation

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 11
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: gradle
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 11
         cache: gradle
     - name: Read .nvmrc

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
+        cache: gradle
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm
@@ -31,12 +32,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
-    - uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+        cache: npm
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
         cache: npm
+      if: matrix.gradle == '6.9'
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: gradle
       - name: Read .nvmrc

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 11
+          cache: gradle
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
@@ -23,6 +24,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          cache: npm
       - name: Generate Groovydoc
         run: ./gradlew groovydoc
       - name: Prepare to Deploy


### PR DESCRIPTION
1. Update `setup-java` and `setup-node` to use [the built-in dependency caching](https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/)
2. Replace AdoptOpenJDK with [its successor Eclipse Temurin](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).