### PR TITLE
provide better support for Gradle config cache

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -16,6 +16,7 @@ package com.github.spotbugs.snom
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.util.GradleVersion
+import spock.lang.Requires
 import spock.lang.Specification
 
 import java.nio.file.Files
@@ -41,8 +42,8 @@ class CacheabilityFunctionalTest extends Specification {
 
         def version = System.getProperty('snom.test.functional.gradle', GradleVersion.current().version)
 
-        initializeBuildFile(buildDir1)
-        initializeBuildFile(buildDir2)
+        initializeBuildFile(buildDir1, !version.startsWith('5'))
+        initializeBuildFile(buildDir2, !version.startsWith('5'))
 
         when:
         BuildResult result1 =
@@ -78,7 +79,7 @@ class CacheabilityFunctionalTest extends Specification {
         return result.output.find('Build cache key for task \':spotbugsMain\' is .*')
     }
 
-    private static void initializeBuildFile(File buildDir) {
+    private static void initializeBuildFile(File buildDir, boolean runScan) {
         File buildFile = new File(buildDir, 'build.gradle')
         File settingsFile = new File(buildDir, 'settings.gradle')
         File propertiesFile = new File(buildDir, 'gradle.properties')
@@ -96,17 +97,19 @@ class CacheabilityFunctionalTest extends Specification {
             |}
             |'''.stripMargin()
 
-        settingsFile << '''
-            |plugins {
-            |    id "com.gradle.enterprise" version "3.6.4"
-            |}
-            |gradleEnterprise {
-            |    buildScan {
-            |        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-            |        termsOfServiceAgree = "yes"
-            |    }
-            |}
-            '''.stripMargin()
+        if (runScan) {
+            settingsFile << '''
+                |plugins {
+                |    id "com.gradle.enterprise" version "3.6.4"
+                |}
+                |gradleEnterprise {
+                |    buildScan {
+                |        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+                |        termsOfServiceAgree = "yes"
+                |    }
+                |}
+                '''.stripMargin()
+        }
         File sourceDir = buildDir.toPath().resolve('src').resolve('main').resolve('java').toFile()
         sourceDir.mkdirs()
         File sourceFile = new File(sourceDir, 'Foo.java')

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -62,7 +62,7 @@ class CacheabilityFunctionalTest extends Specification {
         BuildResult result2 =
                 GradleRunner.create()
                 .withProjectDir(buildDir2)
-                .withArguments(':spotbugsMain')
+                .withArguments(':spotbugsMain', '--scan')
                 .withPluginClasspath()
                 .forwardOutput()
                 .withGradleVersion(version)
@@ -80,6 +80,7 @@ class CacheabilityFunctionalTest extends Specification {
 
     private static void initializeBuildFile(File buildDir) {
         File buildFile = new File(buildDir, 'build.gradle')
+        File settingsFile = new File(buildDir, 'settings.gradle')
         File propertiesFile = new File(buildDir, 'gradle.properties')
 
         buildFile << '''
@@ -95,6 +96,17 @@ class CacheabilityFunctionalTest extends Specification {
             |}
             |'''.stripMargin()
 
+        settingsFile << '''
+            |plugins {
+            |    id "com.gradle.enterprise" version "3.6.4"
+            |}
+            |gradleEnterprise {
+            |    buildScan {
+            |        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            |        termsOfServiceAgree = "yes"
+            |    }
+            |}
+            '''.stripMargin()
         File sourceDir = buildDir.toPath().resolve('src').resolve('main').resolve('java').toFile()
         sourceDir.mkdirs()
         File sourceFile = new File(sourceDir, 'Foo.java')

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -40,6 +40,7 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
 
   @Override
   public void apply(Project project) {
+    boolean isSpotBugsPluginApplied = project.getPluginManager().hasPlugin("com.github.spotbugs");
     verifyGradleVersion(GradleVersion.current());
     project.getPluginManager().apply(ReportingBasePlugin.class);
 
@@ -56,6 +57,7 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
             task ->
                 task.init(
                     extension,
+                    isSpotBugsPluginApplied,
                     Boolean.parseBoolean(enableWorkerApi),
                     Boolean.parseBoolean(enableHybridWorker)));
   }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -40,6 +40,7 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
 
   @Override
   public void apply(Project project) {
+    // use XML report by default, only when SpotBugs plugin is applied
     boolean isSpotBugsPluginApplied = project.getPluginManager().hasPlugin("com.github.spotbugs");
     verifyGradleVersion(GradleVersion.current());
     project.getPluginManager().apply(ReportingBasePlugin.class);

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -26,6 +26,9 @@ import org.gradle.api.plugins.ReportingBasePlugin;
 import org.gradle.util.GradleVersion;
 
 public class SpotBugsBasePlugin implements Plugin<Project> {
+  static final String FEATURE_FLAG_WORKER_API = "com.github.spotbugs.snom.worker";
+  static final String FEATURE_FLAG_HYBRID_WORKER = "com.github.spotbugs.snom.javaexec-in-worker";
+
   /**
    * Supported Gradle version described at <a
    * href="http://spotbugs.readthedocs.io/en/latest/gradle.html">official manual site</a>. <a
@@ -42,7 +45,18 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
     SpotBugsExtension extension = createExtension(project);
     createConfiguration(project, extension);
     createPluginConfiguration(project);
-    project.getTasks().withType(SpotBugsTask.class).configureEach(task -> task.init(extension));
+
+    String enableWorkerApi = getPropertyOrDefault(project, FEATURE_FLAG_WORKER_API, "true");
+    String enableHybridWorker = getPropertyOrDefault(project, FEATURE_FLAG_HYBRID_WORKER, "false");
+    project
+        .getTasks()
+        .withType(SpotBugsTask.class)
+        .configureEach(
+            task ->
+                task.init(
+                    extension,
+                    Boolean.parseBoolean(enableWorkerApi),
+                    Boolean.parseBoolean(enableHybridWorker)));
   }
 
   private SpotBugsExtension createExtension(Project project) {
@@ -116,5 +130,11 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
               version, SUPPORTED_VERSION);
       throw new IllegalArgumentException(message);
     }
+  }
+
+  private String getPropertyOrDefault(Project project, String propertyName, String defaultValue) {
+    return project.hasProperty(propertyName)
+        ? project.property(propertyName).toString()
+        : defaultValue;
   }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -26,8 +26,9 @@ import org.gradle.api.plugins.ReportingBasePlugin;
 import org.gradle.util.GradleVersion;
 
 public class SpotBugsBasePlugin implements Plugin<Project> {
-  static final String FEATURE_FLAG_WORKER_API = "com.github.spotbugs.snom.worker";
-  static final String FEATURE_FLAG_HYBRID_WORKER = "com.github.spotbugs.snom.javaexec-in-worker";
+  private static final String FEATURE_FLAG_WORKER_API = "com.github.spotbugs.snom.worker";
+  private static final String FEATURE_FLAG_HYBRID_WORKER =
+      "com.github.spotbugs.snom.javaexec-in-worker";
 
   /**
    * Supported Gradle version described at <a

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -49,6 +49,24 @@ public class SpotBugsPlugin implements Plugin<Project> {
   }
 
   private void createTasks(Project project, SpotBugsExtension extension) {
-    new SpotBugsTaskFactory().generate(project, task -> task.init(extension));
+    String enableWorkerApi =
+        getPropertyOrDefault(project, SpotBugsBasePlugin.FEATURE_FLAG_WORKER_API, "true");
+    String enableHybridWorker =
+        getPropertyOrDefault(project, SpotBugsBasePlugin.FEATURE_FLAG_HYBRID_WORKER, "false");
+
+    new SpotBugsTaskFactory()
+        .generate(
+            project,
+            task ->
+                task.init(
+                    extension,
+                    Boolean.parseBoolean(enableWorkerApi),
+                    Boolean.parseBoolean(enableHybridWorker)));
+  }
+
+  private String getPropertyOrDefault(Project project, String propertyName, String defaultValue) {
+    return project.hasProperty(propertyName)
+        ? project.property(propertyName).toString()
+        : defaultValue;
   }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -31,7 +31,6 @@ public class SpotBugsPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     project.getPluginManager().apply(SpotBugsBasePlugin.class);
-    SpotBugsExtension extension = project.getExtensions().findByType(SpotBugsExtension.class);
     project
         .getPluginManager()
         .withPlugin(
@@ -45,10 +44,10 @@ public class SpotBugsPlugin implements Plugin<Project> {
                   .configure(
                       task -> task.dependsOn(project.getTasks().withType(SpotBugsTask.class)));
             });
-    createTasks(project, extension);
+    createTasks(project);
   }
 
-  private void createTasks(Project project, SpotBugsExtension extension) {
+  private void createTasks(Project project) {
     new SpotBugsTaskFactory().generate(project);
   }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsPlugin.java
@@ -49,24 +49,6 @@ public class SpotBugsPlugin implements Plugin<Project> {
   }
 
   private void createTasks(Project project, SpotBugsExtension extension) {
-    String enableWorkerApi =
-        getPropertyOrDefault(project, SpotBugsBasePlugin.FEATURE_FLAG_WORKER_API, "true");
-    String enableHybridWorker =
-        getPropertyOrDefault(project, SpotBugsBasePlugin.FEATURE_FLAG_HYBRID_WORKER, "false");
-
-    new SpotBugsTaskFactory()
-        .generate(
-            project,
-            task ->
-                task.init(
-                    extension,
-                    Boolean.parseBoolean(enableWorkerApi),
-                    Boolean.parseBoolean(enableHybridWorker)));
-  }
-
-  private String getPropertyOrDefault(Project project, String propertyName, String defaultValue) {
-    return project.hasProperty(propertyName)
-        ? project.property(propertyName).toString()
-        : defaultValue;
+    new SpotBugsTaskFactory().generate(project);
   }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -262,6 +262,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
 
     private boolean enableWorkerApi;
     private boolean enableHybridWorker;
+    private boolean isSpotBugsPluginApplied;
 
     void setClasses(FileCollection fileCollection) {
         this.classes = fileCollection
@@ -336,7 +337,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
      *
      * @param extension the source extension to copy the properties.
      */
-    void init(SpotBugsExtension extension, boolean enableWorkerApi, boolean enableHybridWorker) {
+    void init(SpotBugsExtension extension, boolean isSpotBugsPluginApplied, boolean enableWorkerApi, boolean enableHybridWorker) {
         ignoreFailures.convention(extension.ignoreFailures)
         showStackTraces.convention(extension.showStackTraces)
         showProgress.convention(extension.showProgress)
@@ -356,6 +357,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         extraArgs.convention(extension.extraArgs)
         maxHeapSize.convention(extension.maxHeapSize)
         useAuxclasspathFile.convention(extension.useAuxclasspathFile)
+        this.isSpotBugsPluginApplied = isSpotBugsPluginApplied
         this.enableWorkerApi = enableWorkerApi
         this.enableHybridWorker = enableHybridWorker
     }
@@ -406,11 +408,8 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Optional
     @Nested
     SpotBugsReport getFirstEnabledReport() {
-        // use XML report by default, only when SpotBugs plugin is applied
-        boolean isSpotBugsPluingApplied = project.pluginManager.hasPlugin("com.github.spotbugs")
-
         java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.enabled}).findFirst()
-        if (isSpotBugsPluingApplied) {
+        if (isSpotBugsPluginApplied) {
             return report.orElse(reports.create("xml"))
         } else {
             return report.orElse(null)

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -91,8 +91,6 @@ import javax.inject.Inject
 
 @CacheableTask
 class SpotBugsTask extends DefaultTask implements VerificationTask {
-    private static final String FEATURE_FLAG_WORKER_API = "com.github.spotbugs.snom.worker";
-    private static final String FEATURE_FLAG_HYBRID_WORKER = "com.github.spotbugs.snom.javaexec-in-worker";
     private final Logger log = LoggerFactory.getLogger(SpotBugsTask);
 
     private final WorkerExecutor workerExecutor;
@@ -262,6 +260,9 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
 
     private FileCollection classes;
 
+    private boolean enableWorkerApi;
+    private boolean enableHybridWorker;
+
     void setClasses(FileCollection fileCollection) {
         this.classes = fileCollection
     }
@@ -335,7 +336,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
      *
      * @param extension the source extension to copy the properties.
      */
-    void init(SpotBugsExtension extension) {
+    void init(SpotBugsExtension extension, boolean enableWorkerApi, boolean enableHybridWorker) {
         ignoreFailures.convention(extension.ignoreFailures)
         showStackTraces.convention(extension.showStackTraces)
         showProgress.convention(extension.showProgress)
@@ -355,17 +356,16 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         extraArgs.convention(extension.extraArgs)
         maxHeapSize.convention(extension.maxHeapSize)
         useAuxclasspathFile.convention(extension.useAuxclasspathFile)
+        this.enableWorkerApi = enableWorkerApi
+        this.enableHybridWorker = enableHybridWorker
     }
 
     @TaskAction
     void run() {
-        String enableWorkerApi = project.properties.getOrDefault(FEATURE_FLAG_WORKER_API, "true")
-        String enableHybridWorker = project.properties.getOrDefault(FEATURE_FLAG_HYBRID_WORKER, "false")
-
-        if (enableWorkerApi == "false") {
+        if (!enableWorkerApi) {
             log.info("Running SpotBugs by JavaExec...");
             new SpotBugsRunnerForJavaExec().run(this);
-        } else if (enableHybridWorker == "true" && GradleVersion.current() >= GradleVersion.version("6.0")) {
+        } else if (enableHybridWorker && GradleVersion.current() >= GradleVersion.version("6.0")) {
             // ExecOperations is supported from Gradle 6.0
             log.info("Running SpotBugs by Gradle no-isolated Worker...");
             new SpotBugsRunnerForHybrid(workerExecutor).run(this);

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsTaskFactory.java
@@ -33,12 +33,12 @@ import org.slf4j.LoggerFactory;
 public class SpotBugsTaskFactory {
   private final Logger log = LoggerFactory.getLogger(SpotBugsTaskFactory.class);
 
-  public void generate(Project project, Action<? super SpotBugsTask> configurationAction) {
-    generateForJava(project, configurationAction);
-    generateForAndroid(project, configurationAction);
+  public void generate(Project project) {
+    generateForJava(project);
+    generateForAndroid(project);
   }
 
-  private void generateForJava(Project project, Action<? super SpotBugsTask> configurationAction) {
+  private void generateForJava(Project project) {
     project
         .getPlugins()
         .withType(JavaBasePlugin.class)
@@ -62,14 +62,12 @@ public class SpotBugsTaskFactory {
                                       sourceSet.getAllSource().getSourceDirectories());
                                   task.setClassDirs(sourceSet.getOutput());
                                   task.setAuxClassPaths(sourceSet.getCompileClasspath());
-                                  configurationAction.execute(task);
                                 });
                       });
             });
   }
 
-  private void generateForAndroid(
-      Project project, Action<? super SpotBugsTask> configurationAction) {
+  private void generateForAndroid(Project project) {
 
     @SuppressWarnings("rawtypes")
     final Action<? super Plugin> action =
@@ -103,7 +101,6 @@ public class SpotBugsTaskFactory {
                                   project.files(javaCompile.getDestinationDir()));
                               spotbugsTask.setAuxClassPaths(javaCompile.getClasspath());
                               spotbugsTask.dependsOn(javaCompile);
-                              configurationAction.execute(spotbugsTask);
                             });
                   });
             };


### PR DESCRIPTION
Stop accessing the `Project` during the execution phase, to provide better support for Gradle's config cache.
close #446