### PR TITLE
First v5 beta release

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - master
+      - beta
   pull_request:
     branches:
       - master
+      - beta
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gradle: ['5.6.4', '6.9', '7.0']
+        gradle: ['7.0', '7.2']
     steps:
     - uses: actions/checkout@v2
       with:
@@ -33,7 +33,7 @@ jobs:
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
         cache: npm
-      if: matrix.gradle == '6.9'
+      if: matrix.gradle == '7.0'
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
@@ -52,7 +52,7 @@ jobs:
         rm -rf build/libs/*.jar
         npm ci
         npx semantic-release
-      if: matrix.gradle == '6.9'
+      if: matrix.gradle == '7.0'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run SonarQube Scanner
@@ -60,7 +60,7 @@ jobs:
         if [ "$SONAR_LOGIN" != "" ]; then
           ./gradlew sonarqube -Dsonar.login=$SONAR_LOGIN --no-daemon
         fi
-      if: matrix.gradle == '6.9'
+      if: matrix.gradle == '7.0'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -95,6 +95,11 @@ class CacheabilityFunctionalTest extends Specification {
             |repositories {
             |    mavenCentral()
             |}
+            |spotbugsMain {
+            |    reports {
+            |        text.enabled = true
+            |    }
+            |}
             |'''.stripMargin()
 
         if (runScan) {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/GradleJavaToolchainsSupportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/GradleJavaToolchainsSupportFunctionalTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 SpotBugs team
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.spotbugs.snom
+
+import org.gradle.internal.impldep.com.google.common.io.Files
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
+import org.junit.jupiter.api.BeforeEach
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class GradleJavaToolchainsSupportFunctionalTest extends Specification {
+    File rootDir
+    File buildFile
+    String version = System.getProperty('snom.test.functional.gradle', GradleVersion.current().version)
+
+    @BeforeEach
+    def setup() {
+        rootDir = Files.createTempDir()
+        buildFile = new File(rootDir, 'build.gradle')
+        buildFile << """
+plugins {
+    id 'java'
+    id 'com.github.spotbugs'
+}
+
+version = 1.0
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(16)
+    }
+}
+        """
+        File sourceDir = rootDir.toPath().resolve("src").resolve("main").resolve("java").toFile()
+        sourceDir.mkdirs()
+        File sourceFile = new File(sourceDir, "Foo.java")
+        sourceFile << """
+public class Foo {
+    public static void main(String... args) {
+        System.out.println("Hello, SpotBugs!");
+    }
+}
+"""
+    }
+
+    @Unroll
+    def 'Supports Gradle Java Toolchains (#processConfiguration)'() {
+        setup:
+        buildFile << """
+        spotbugs {
+          useJavaToolchains = true
+        }"""
+
+        when:
+        def arguments = [':spotbugsMain', '-is']
+        arguments.add(processConfigurationArgument)
+
+        def runner = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+
+        def result = runner.build()
+
+        then:
+        result.task(':spotbugsMain').outcome == SUCCESS
+        result.output.contains('Spotbugs will be executed using Java Toolchain configuration')
+
+        where:
+        processConfiguration | processConfigurationArgument
+        'javaexec'           | '-Pcom.github.spotbugs.snom.worker=false'
+        'worker-api'         | '-Pcom.github.spotbugs.snom.worker=true'
+        'javaexec-in-worker' | '-Pcom.github.spotbugs.snom.javaexec-in-worker=true'
+    }
+
+    @Unroll
+    def 'Do not use Gradle Java Toolchains if extension is not configured (#processConfiguration)'() {
+        when:
+        def arguments = [':spotbugsMain', '-is']
+        arguments.add(processConfigurationArgument)
+
+        def runner = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments(arguments)
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+
+        def result = runner.build()
+
+        then:
+        result.task(':spotbugsMain').outcome == SUCCESS
+        !result.output.contains('Spotbugs will be executed using Java Toolchain configuration')
+
+
+        where:
+        processConfiguration | processConfigurationArgument
+        'javaexec'           | '-Pcom.github.spotbugs.snom.worker=false'
+        'worker-api'         | '-Pcom.github.spotbugs.snom.worker=true'
+        'javaexec-in-worker' | '-Pcom.github.spotbugs.snom.javaexec-in-worker=true'
+    }
+}

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -632,6 +632,13 @@ public class SimpleTest {
     @Unroll
     def 'shows report path when failures are found (Worker API? #isWorkerApi)'() {
         given:
+        buildFile << """
+spotbugsMain {
+    reports {
+        xml.enabled = true
+    }
+}"""
+
         def badCode = new File(rootDir, 'src/main/java/Bar.java')
         badCode << '''
         |public class Bar {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsBasePlugin.java
@@ -36,12 +36,10 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
    * href="https://guides.gradle.org/using-the-worker-api/">The Gradle Worker API</a> needs 5.6 or
    * later, so we use this value as minimal required version.
    */
-  private static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("5.6");
+  private static final GradleVersion SUPPORTED_VERSION = GradleVersion.version("7.0");
 
   @Override
   public void apply(Project project) {
-    // use XML report by default, only when SpotBugs plugin is applied
-    boolean isSpotBugsPluginApplied = project.getPluginManager().hasPlugin("com.github.spotbugs");
     verifyGradleVersion(GradleVersion.current());
     project.getPluginManager().apply(ReportingBasePlugin.class);
 
@@ -58,7 +56,6 @@ public class SpotBugsBasePlugin implements Plugin<Project> {
             task ->
                 task.init(
                     extension,
-                    isSpotBugsPluginApplied,
                     Boolean.parseBoolean(enableWorkerApi),
                     Boolean.parseBoolean(enableHybridWorker)));
   }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -156,6 +156,9 @@ class SpotBugsExtension {
     @NonNull
     final Property<Boolean> useAuxclasspathFile;
 
+    @NonNull
+    final Property<Boolean> useJavaToolchains
+
     @Inject
     SpotBugsExtension(Project project, ObjectFactory objects) {
         ignoreFailures = objects.property(Boolean).convention(false);
@@ -188,6 +191,7 @@ class SpotBugsExtension {
         maxHeapSize = objects.property(String);
         toolVersion = objects.property(String)
         useAuxclasspathFile = objects.property(Boolean).convention(false)
+        useJavaToolchains = objects.property(Boolean).convention(false)
     }
 
     void setReportLevel(@Nullable String name) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -412,11 +412,7 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Nested
     SpotBugsReport getFirstEnabledReport() {
         java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.enabled}).findFirst()
-        if (isSpotBugsPluginApplied) {
-            return report.orElse(reports.create("xml"))
-        } else {
-            return report.orElse(null)
-        }
+        return report.orElse(null)
     }
 
     void setReportLevel(@Nullable String name) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -24,6 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SkipWhenEmpty
@@ -48,7 +49,9 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.VerificationTask;
+import org.gradle.api.tasks.VerificationTask
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.util.ClosureBackedAction
 import org.gradle.util.GradleVersion;
 import org.gradle.workers.WorkerExecutor;
@@ -91,7 +94,10 @@ import javax.inject.Inject
  */
 
 @CacheableTask
-class SpotBugsTask extends DefaultTask implements VerificationTask {
+abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
+    private static final String FEATURE_FLAG_WORKER_API = "com.github.spotbugs.snom.worker";
+    private static final String FEATURE_FLAG_HYBRID_WORKER = "com.github.spotbugs.snom.javaexec-in-worker";
+
     private final Logger log = LoggerFactory.getLogger(SpotBugsTask);
 
     private final WorkerExecutor workerExecutor;
@@ -290,6 +296,10 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         }
     }
 
+    @Nested
+    @Optional
+    abstract Property<JavaLauncher> getLauncher()
+
     @Inject
     SpotBugsTask(ObjectFactory objects, WorkerExecutor workerExecutor) {
         this.workerExecutor = Objects.requireNonNull(workerExecutor);
@@ -360,23 +370,39 @@ class SpotBugsTask extends DefaultTask implements VerificationTask {
         extraArgs.convention(extension.extraArgs)
         maxHeapSize.convention(extension.maxHeapSize)
         useAuxclasspathFile.convention(extension.useAuxclasspathFile)
+
+        if(extension.useJavaToolchains.isPresent() && extension.useJavaToolchains.get()) {
+            configureJavaLauncher()
+        }
+
         this.isSpotBugsPluginApplied = isSpotBugsPluginApplied
         this.enableWorkerApi = enableWorkerApi
         this.enableHybridWorker = enableHybridWorker
+    }
+
+
+    /**
+     * Set convention for default java launcher based on Toolchain configuration
+     */
+    private void configureJavaLauncher() {
+        def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).toolchain
+        JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class)
+        Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain)
+        launcher.convention(defaultLauncher)
     }
 
     @TaskAction
     void run() {
         if (!enableWorkerApi) {
             log.info("Running SpotBugs by JavaExec...");
-            new SpotBugsRunnerForJavaExec().run(this);
+            new SpotBugsRunnerForJavaExec(launcher).run(this);
         } else if (enableHybridWorker && GradleVersion.current() >= GradleVersion.version("6.0")) {
             // ExecOperations is supported from Gradle 6.0
             log.info("Running SpotBugs by Gradle no-isolated Worker...");
-            new SpotBugsRunnerForHybrid(workerExecutor).run(this);
+            new SpotBugsRunnerForHybrid(workerExecutor, launcher).run(this);
         } else {
             log.info("Running SpotBugs by Gradle process-isolated Worker...");
-            new SpotBugsRunnerForWorker(workerExecutor).run(this);
+            new SpotBugsRunnerForWorker(workerExecutor, launcher).run(this);
         }
     }
 

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -269,7 +269,6 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
 
     private boolean enableWorkerApi;
     private boolean enableHybridWorker;
-    private boolean isSpotBugsPluginApplied;
 
     void setClasses(FileCollection fileCollection) {
         this.classes = fileCollection
@@ -350,7 +349,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
      *
      * @param extension the source extension to copy the properties.
      */
-    void init(SpotBugsExtension extension, boolean isSpotBugsPluginApplied, boolean enableWorkerApi, boolean enableHybridWorker) {
+    void init(SpotBugsExtension extension, boolean enableWorkerApi, boolean enableHybridWorker) {
         ignoreFailures.convention(extension.ignoreFailures)
         showStackTraces.convention(extension.showStackTraces)
         showProgress.convention(extension.showProgress)
@@ -375,7 +374,6 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
             configureJavaLauncher()
         }
 
-        this.isSpotBugsPluginApplied = isSpotBugsPluginApplied
         this.enableWorkerApi = enableWorkerApi
         this.enableHybridWorker = enableHybridWorker
     }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
@@ -30,6 +30,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.internal.ExecException;
@@ -50,9 +51,12 @@ import org.slf4j.LoggerFactory;
  */
 class SpotBugsRunnerForHybrid extends SpotBugsRunner {
   private final WorkerExecutor workerExecutor;
+  private final Property<JavaLauncher> javaLauncher;
 
-  public SpotBugsRunnerForHybrid(@NonNull WorkerExecutor workerExecutor) {
+  public SpotBugsRunnerForHybrid(
+      @NonNull WorkerExecutor workerExecutor, Property<JavaLauncher> javaLauncher) {
     this.workerExecutor = Objects.requireNonNull(workerExecutor);
+    this.javaLauncher = javaLauncher;
   }
 
   @Override
@@ -75,6 +79,11 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
       params.getIgnoreFailures().set(task.getIgnoreFailures());
       params.getShowStackTraces().set(task.getShowStackTraces());
       params.getReportsDir().set(task.getReportsDir());
+      if (javaLauncher.isPresent()) {
+        params
+            .getJavaToolchainExecutablePath()
+            .set(javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath());
+      }
     };
   }
 
@@ -92,6 +101,8 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
     Property<Boolean> getShowStackTraces();
 
     DirectoryProperty getReportsDir();
+
+    Property<String> getJavaToolchainExecutablePath();
   }
 
   public abstract static class SpotBugsExecutor implements WorkAction<SpotBugsWorkParameters> {
@@ -139,6 +150,12 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
         String maxHeapSize = params.getMaxHeapSize().getOrNull();
         if (maxHeapSize != null) {
           spec.setMaxHeapSize(maxHeapSize);
+        }
+        if (params.getJavaToolchainExecutablePath().isPresent()) {
+          log.info(
+              "Spotbugs will be executed using Java Toolchain configuration: {}",
+              params.getJavaToolchainExecutablePath().get());
+          spec.setExecutable(params.getJavaToolchainExecutablePath().get());
         }
       };
     }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForJavaExec.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
+import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.internal.ExecException;
 import org.slf4j.Logger;
@@ -30,6 +32,11 @@ import org.slf4j.LoggerFactory;
 
 public class SpotBugsRunnerForJavaExec extends SpotBugsRunner {
   private final Logger log = LoggerFactory.getLogger(SpotBugsRunnerForJavaExec.class);
+  private final Property<JavaLauncher> javaLauncher;
+
+  public SpotBugsRunnerForJavaExec(Property<JavaLauncher> javaLauncher) {
+    this.javaLauncher = javaLauncher;
+  }
 
   @Override
   public void run(@NonNull SpotBugsTask task) {
@@ -67,6 +74,13 @@ public class SpotBugsRunnerForJavaExec extends SpotBugsRunner {
       String maxHeapSize = task.getMaxHeapSize().getOrNull();
       if (maxHeapSize != null) {
         spec.setMaxHeapSize(maxHeapSize);
+      }
+      if (javaLauncher.isPresent()) {
+        log.info(
+            "Spotbugs will be executed using Java Toolchain configuration: Vendor: {} | Version: {}",
+            javaLauncher.get().getMetadata().getVendor(),
+            javaLauncher.get().getMetadata().getLanguageVersion().asInt());
+        spec.setExecutable(javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath());
       }
     };
   }

--- a/src/test/java/com/github/spotbugs/snom/SpotBugsPluginTest.java
+++ b/src/test/java/com/github/spotbugs/snom/SpotBugsPluginTest.java
@@ -36,9 +36,9 @@ class SpotBugsPluginTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> {
-          new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("5.5"));
+          new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("6.9"));
         });
-    new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("5.6"));
+    new SpotBugsBasePlugin().verifyGradleVersion(GradleVersion.version("7.0"));
   }
 
   @Test


### PR DESCRIPTION
This PR introduces the following changes, to release `5.0.0-beta1`:

* #526
* #363

It also drops support for Gradle v5 and v6, to use Gradle's toolchain support (refer to #526).