### PR TITLE
Set the useAuxclasspathFile option by default

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -549,12 +549,9 @@ public class FooTest {
         !result.output.contains("Trying to add already registered factory")
     }
 
-    def "can apply plugin using useAuxclasspathFile flag"() {
+    def "can apply plugin using useAuxclasspathFile flag by default"() {
         given:
         buildFile << """
-spotbugs {
-  useAuxclasspathFile = true
-}
 dependencies {
   implementation 'com.google.guava:guava:19.0'
 }"""

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsExtension.groovy
@@ -189,7 +189,7 @@ class SpotBugsExtension {
         extraArgs = objects.listProperty(String);
         maxHeapSize = objects.property(String);
         toolVersion = objects.property(String)
-        useAuxclasspathFile = objects.property(Boolean).convention(false)
+        useAuxclasspathFile = objects.property(Boolean).convention(true)
         useJavaToolchains = objects.property(Boolean).convention(false)
     }
 


### PR DESCRIPTION
Enable the `useAuxclasspathFile` option by default, to avoid the "command line exceed operating system limits" problem on the Windows platform. Refs #243