### PR TITLE
chore: Include SCM information in POM

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -29,6 +29,11 @@ gradlePlugin {
 
 publishing.publications.all {
     pom {
+        scm {
+            connection = 'scm:git:git@github.com:spotbugs/spotbugs-gradle-plugin.git'
+            developerConnection = 'scm:git:git@github.com:spotbugs/spotbugs-gradle-plugin.git'
+            url = 'https://github.com/spotbugs/spotbugs-gradle-plugin/'
+        }
         licenses {
             license {
                 name = 'Apache License 2.0'


### PR DESCRIPTION
Including SCM information in POM should allow tools like Dependabot figure out the release information. This information is processed correctly for Spotbugs itself, so I just adapted the `scm` block from https://github.com/spotbugs/spotbugs-gradle-plugin/blob/master/gradle/publish.gradle