### PR TITLE
`required` property cannot disable the report

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gradle: ['7.0', '7.3']
+        gradle: ['7.0', '7.3.1']
     steps:
     - uses: actions/checkout@v2
       with:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("com.gradle.enterprise") version("3.7.2")
+}
+
+rootProject.name = "spotbugs-gradle-plugin"
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -503,4 +503,26 @@ spotbugsMain {
         assertTrue(reportDir.resolve("main.xml").toFile().isFile())
         assertTrue(reportDir.resolve("main.sarif").toFile().isFile())
     }
+
+    def "can disable XML report"() {
+        buildFile << """
+spotbugsMain {
+    reports {
+        xml.required = false
+    }
+}"""
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(rootDir)
+                .withArguments('spotbugsMain')
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+
+        then:
+        assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
+
+        Path reportDir = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs")
+        assertFalse(reportDir.resolve("main.xml").toFile().isFile())
+    }
 }

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -484,8 +484,8 @@ spotbugsMain {
         buildFile << """
 spotbugsMain {
     reports {
-        xml.enabled = true
-        sarif.enabled = true
+        xml.required = true
+        sarif.required = true
     }
 }"""
         when:

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -36,15 +36,13 @@ public abstract class SpotBugsReport
         CustomizableHtmlReport // to expose CustomizableHtmlReport#setStylesheet to build script
 {
   private final RegularFileProperty destination;
-  private final Property<Boolean> isEnabled;
   private final Property<Boolean> isRequired;
   private final SpotBugsTask task;
 
   @Inject
   public SpotBugsReport(ObjectFactory objects, SpotBugsTask task) {
     this.destination = objects.fileProperty();
-    this.isEnabled = objects.property(Boolean.class);
-    this.isRequired = objects.property(Boolean.class).value(Boolean.TRUE);
+    this.isRequired = objects.property(Boolean.class).convention(Boolean.TRUE);
     this.task = task;
   }
 
@@ -79,21 +77,21 @@ public abstract class SpotBugsReport
   @Deprecated
   @Override
   public boolean isEnabled() {
-    return isEnabled.getOrElse(Boolean.TRUE);
+    return isRequired.get();
   }
 
   /** @deprecated use {@code getRequired().set(value)} instead. */
   @Deprecated
   @Override
   public void setEnabled(boolean b) {
-    isEnabled.set(b);
+    isRequired.set(b);
   }
 
   /** @deprecated use {@code getRequired().set(provider)} instead. */
   @Deprecated
   @Override
   public void setEnabled(Provider<Boolean> provider) {
-    isEnabled.set(provider);
+    isRequired.set(provider);
   }
 
   /** @deprecated use {@code getOutputLocation().set(file)} instead. */

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -434,7 +434,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Optional
     @Nested
     SpotBugsReport getFirstEnabledReport() {
-        java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.enabled || report.required}).findFirst()
+        java.util.Optional<SpotBugsReport> report = reports.stream().filter({ report -> report.enabled }).findFirst()
         return report.orElse(null)
     }
 
@@ -442,7 +442,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Optional
     @Nested
     Set<SpotBugsReport> getEnabledReports() {
-        return reports.findAll {it.enabled}
+        return reports.findAll { it.enabled }
     }
 
     void setReportLevel(@Nullable String name) {


### PR DESCRIPTION
1. Bump up Gradle to the latest release
2. Add a HTML type report
3. Add a `settings.gradle.kts` file as suggested by the [Gradle official user guide](https://docs.gradle.org/7.3.1/userguide/organizing_gradle_projects.html#always_define_a_settings_file).
4. Reproduce and fix the [reported issue](https://github.com/spotbugs/spotbugs-gradle-plugin/issues/629#issuecomment-987013464)