### PR TITLE
fix: support Gradle configuration cache

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -16,13 +16,34 @@ package com.github.spotbugs.snom
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.util.GradleVersion
-import spock.lang.Requires
 import spock.lang.Specification
 
 import java.nio.file.Files
 
 class CacheabilityFunctionalTest extends Specification {
+    /**
+     * @see <a href="https://github.com/spotbugs/spotbugs-gradle-plugin/issues/662">GitHub Issues</a>
+     */
+    def 'spotbugsMain task runs with configuration cache'() {
+        given:
+        def buildDir = Files.createTempDirectory(null).toFile()
+        def version = System.getProperty('snom.test.functional.gradle', GradleVersion.current().version)
 
+        initializeBuildFile(buildDir)
+
+        when:
+        BuildResult result =
+                GradleRunner.create()
+                        .withProjectDir(buildDir)
+                        .withArguments(':spotbugsMain', '--configuration-cache')
+                        .withPluginClasspath()
+                        .forwardOutput()
+                        .withGradleVersion(version)
+                        .build()
+
+        then:
+        !result.output.contains("Configuration cache problems found in this build")
+    }
 
     /**
      * Verifies the cacheability of {@link SpotBugsTask} by invoking the same code
@@ -42,8 +63,8 @@ class CacheabilityFunctionalTest extends Specification {
 
         def version = System.getProperty('snom.test.functional.gradle', GradleVersion.current().version)
 
-        initializeBuildFile(buildDir1, !version.startsWith('5'))
-        initializeBuildFile(buildDir2, !version.startsWith('5'))
+        initializeBuildFile(buildDir1)
+        initializeBuildFile(buildDir2)
 
         when:
         BuildResult result1 =
@@ -79,7 +100,7 @@ class CacheabilityFunctionalTest extends Specification {
         return result.output.find('Build cache key for task \':spotbugsMain\' is .*')
     }
 
-    private static void initializeBuildFile(File buildDir, boolean runScan) {
+    private static void initializeBuildFile(File buildDir) {
         File buildFile = new File(buildDir, 'build.gradle')
         File settingsFile = new File(buildDir, 'settings.gradle')
         File propertiesFile = new File(buildDir, 'gradle.properties')
@@ -102,19 +123,17 @@ class CacheabilityFunctionalTest extends Specification {
             |}
             |'''.stripMargin()
 
-        if (runScan) {
-            settingsFile << '''
-                |plugins {
-                |    id "com.gradle.enterprise" version "3.6.4"
-                |}
-                |gradleEnterprise {
-                |    buildScan {
-                |        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-                |        termsOfServiceAgree = "yes"
-                |    }
-                |}
-                '''.stripMargin()
-        }
+        settingsFile << '''
+            |plugins {
+            |    id "com.gradle.enterprise" version "3.6.4"
+            |}
+            |gradleEnterprise {
+            |    buildScan {
+            |        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            |        termsOfServiceAgree = "yes"
+            |    }
+            |}
+            '''.stripMargin()
         File sourceDir = buildDir.toPath().resolve('src').resolve('main').resolve('java').toFile()
         sourceDir.mkdirs()
         File sourceFile = new File(sourceDir, 'Foo.java')

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -43,6 +43,7 @@ class CacheabilityFunctionalTest extends Specification {
 
         then:
         !result.output.contains("Configuration cache problems found in this build")
+        result.output.contains("Configuration cache entry stored.")
     }
 
     /**

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -15,6 +15,7 @@ package com.github.spotbugs.snom
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
 import spock.lang.Specification
 
@@ -44,6 +45,18 @@ class CacheabilityFunctionalTest extends Specification {
         then:
         !result.output.contains("Configuration cache problems found in this build")
         result.output.contains("Configuration cache entry stored.")
+
+        when:
+        BuildResult resultOfCachedBuild = GradleRunner.create()
+                .withProjectDir(buildDir)
+                .withArguments(':spotbugsMain', '--configuration-cache')
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+                .build()
+        then:
+        resultOfCachedBuild.task(":spotbugsMain").outcome == TaskOutcome.UP_TO_DATE
+        resultOfCachedBuild.output.contains("Configuration cache entry reused.")
     }
 
     /**

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -34,12 +34,12 @@ class CacheabilityFunctionalTest extends Specification {
         when:
         BuildResult result =
                 GradleRunner.create()
-                        .withProjectDir(buildDir)
-                        .withArguments(':spotbugsMain', '--configuration-cache')
-                        .withPluginClasspath()
-                        .forwardOutput()
-                        .withGradleVersion(version)
-                        .build()
+                .withProjectDir(buildDir)
+                .withArguments(':spotbugsMain', '--configuration-cache')
+                .withPluginClasspath()
+                .forwardOutput()
+                .withGradleVersion(version)
+                .build()
 
         then:
         !result.output.contains("Configuration cache problems found in this build")

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -510,8 +510,9 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
      *
      * @see <a href="https://github.com/spotbugs/spotbugs/releases/tag/4.5.0">GitHub Releases</a>
      */
-    Provider<Boolean> isSupportingMultipleReports() {
-        return isSupportingMultipleReports
+    @Internal
+    boolean isSupportingMultipleReports() {
+        return isSupportingMultipleReports.getOrElse(Boolean.FALSE).booleanValue()
     }
 
     @Internal

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -23,7 +23,6 @@ import com.github.spotbugs.snom.internal.SpotBugsTextReport;
 import com.github.spotbugs.snom.internal.SpotBugsXmlReport;
 import edu.umd.cs.findbugs.annotations.NonNull
 import edu.umd.cs.findbugs.annotations.Nullable
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -36,7 +35,6 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -56,7 +54,6 @@ import org.gradle.api.tasks.VerificationTask
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.util.ClosureBackedAction
-import org.gradle.util.GradleVersion;
 import org.gradle.workers.WorkerExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory
@@ -270,6 +267,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     private boolean enableWorkerApi;
     private boolean enableHybridWorker;
     private FileCollection pluginJarFiles
+    private FileCollection spotbugsClasspath
 
     private Provider<Boolean> isSupportingMultipleReports
 
@@ -355,11 +353,8 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
             configuration.resolve()
             java.util.Optional<Dependency> spotbugs =
                     configuration.getDependencies().stream()
-                            .filter(
-                                    dependency ->
-                                            "com.github.spotbugs" == dependency.getGroup()
-                                                    && "spotbugs" == dependency.getName())
-                            .findFirst()
+                    .filter { dependency -> "com.github.spotbugs" == dependency.group && "spotbugs" == dependency.name }
+                    .findFirst()
             if (!spotbugs.isPresent()) {
                 logger.warn("No spotbugs found in the {} configuration", SpotBugsPlugin.CONFIG_NAME)
                 return false
@@ -367,6 +362,11 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
             SemanticVersion version = new SemanticVersion(spotbugs.get().getVersion())
             logger.debug("Using SpotBugs version {}", version)
             return version >= new SemanticVersion("4.5.0")
+        }
+
+        def spotbugsSlf4j = project.configurations.getByName(SpotBugsPlugin.SLF4J_CONFIG_NAME)
+        spotbugsClasspath = project.layout.files {
+            spotbugsSlf4j.files + configuration.files
         }
     }
 
@@ -451,10 +451,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @NonNull
     @Internal
     FileCollection getSpotbugsClasspath() {
-        Configuration config = getProject().getConfigurations().getByName(SpotBugsPlugin.CONFIG_NAME)
-        Configuration spotbugsSlf4j = getProject().getConfigurations().getByName(SpotBugsPlugin.SLF4J_CONFIG_NAME)
-
-        return getProject().files(config, spotbugsSlf4j)
+        return spotbugsClasspath
     }
 
     @Nullable

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -95,9 +95,6 @@ import javax.inject.Inject
 
 @CacheableTask
 abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
-    private static final String FEATURE_FLAG_WORKER_API = "com.github.spotbugs.snom.worker";
-    private static final String FEATURE_FLAG_HYBRID_WORKER = "com.github.spotbugs.snom.javaexec-in-worker";
-
     private final Logger log = LoggerFactory.getLogger(SpotBugsTask);
 
     private final WorkerExecutor workerExecutor;
@@ -269,6 +266,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
 
     private boolean enableWorkerApi;
     private boolean enableHybridWorker;
+    private FileCollection pluginJarFiles
 
     void setClasses(FileCollection fileCollection) {
         this.classes = fileCollection
@@ -341,6 +339,10 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         useAuxclasspathFile = objects.property(Boolean)
         setDescription("Run SpotBugs analysis.")
         setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+        def pluginConfiguration = project.getConfigurations().getByName(SpotBugsPlugin.PLUGINS_CONFIG_NAME)
+        pluginJarFiles = project.layout.files {
+            pluginConfiguration.files
+        }
     }
 
     /**
@@ -418,7 +420,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @NonNull
     @Internal
     Set<File> getPluginJar() {
-        return getProject().getConfigurations().getByName(SpotBugsPlugin.PLUGINS_CONFIG_NAME).getFiles()
+        return pluginJarFiles.files
     }
 
     @NonNull

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -13,7 +13,6 @@
  */
 package com.github.spotbugs.snom.internal;
 
-import com.github.spotbugs.snom.SpotBugsPlugin;
 import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -28,14 +27,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
-import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -45,30 +45,6 @@ public abstract class SpotBugsRunner {
 
   public abstract void run(@NonNull SpotBugsTask task);
 
-  /**
-   * The multiple reports feature is available from SpotBugs 4.5.0
-   *
-   * @see <a href="https://github.com/spotbugs/spotbugs/releases/tag/4.5.0">GitHub Releases</a>
-   */
-  private boolean isSupportingMultipleReports(Project project) {
-    Configuration configuration = project.getConfigurations().getByName(SpotBugsPlugin.CONFIG_NAME);
-    configuration.resolve();
-    Optional<Dependency> spotbugs =
-        configuration.getDependencies().stream()
-            .filter(
-                dependency ->
-                    "com.github.spotbugs".equals(dependency.getGroup())
-                        && "spotbugs".equals(dependency.getName()))
-            .findFirst();
-    if (!spotbugs.isPresent()) {
-      log.warn("No spotbugs found in the {} configuration", SpotBugsPlugin.CONFIG_NAME);
-      return false;
-    }
-    SemanticVersion version = new SemanticVersion(spotbugs.get().getVersion());
-    log.debug("Using SpotBugs version {}", version);
-    return version.compareTo(new SemanticVersion("4.5.0")) >= 0;
-  }
-
   protected List<String> buildArguments(SpotBugsTask task) {
     List<String> args = new ArrayList<>();
 
@@ -98,7 +74,7 @@ public abstract class SpotBugsRunner {
       args.add("-progress");
     }
 
-    if (isSupportingMultipleReports(task.getProject())) {
+    if (task.isSupportingMultipleReports().get()) {
       for (SpotBugsReport report : task.getEnabledReports()) {
         File reportFile = report.getOutputLocation().getAsFile().get();
         File dir = reportFile.getParentFile();

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -69,7 +69,7 @@ public abstract class SpotBugsRunner {
       args.add("-progress");
     }
 
-    if (task.isSupportingMultipleReports().get()) {
+    if (task.isSupportingMultipleReports()) {
       for (SpotBugsReport report : task.getEnabledReports()) {
         File reportFile = report.getOutputLocation().getAsFile().get();
         File dir = reportFile.getParentFile();


### PR DESCRIPTION
To run the analysis with the Gradle configuration-cache, we need to stop invoking `project.task` at execution phase. To realize it, I applied [lazy `FileCollection` generated via project layout](https://docs.gradle.org/7.3.3/userguide/lazy_configuration.html#working_with_files_in_lazy_properties).

close #662

### Configuration cache log

When I run `CacheabilityFunctionalTest` in my local, I confirmed that the following log was printed in the test report. It proves that a build with `--configuration-cache` option works as expected:

```
Configuration cache is an incubating feature.
Calculating task graph as no configuration cache is available for tasks: :spotbugsMain

> Task :compileJava FROM-CACHE
Appending implementation to build cache key: org.gradle.api.tasks.compile.JavaCompile_Decorated@18a7015cb8ac0a074105719473585a0d
Appending additional implementation to build cache key: org.gradle.api.tasks.compile.JavaCompile_Decorated@18a7015cb8ac0a074105719473585a0d
Appending input value fingerprint for 'javaVersion' to build cache key: a40a171a9de3ed0d81e29d9af4cc27ef
Appending input value fingerprint for 'modularity' to build cache key: c0d4d45c61d414dd712a8fea78de1d01
Appending input value fingerprint for 'modularity.inferModulePath' to build cache key: f6d7ed39fe24031e22d54f3fe65b901c
Appending input value fingerprint for 'options' to build cache key: d5af82f448f063285200faa728feb960
Appending input value fingerprint for 'options.compilerArgs' to build cache key: 8222d82255460164427051d7537fa305
Appending input value fingerprint for 'options.debug' to build cache key: f6d7ed39fe24031e22d54f3fe65b901c
Appending input value fingerprint for 'options.debugOptions' to build cache key: 2755b211a8bdc418879a6ccce09dd220
Appending input value fingerprint for 'options.debugOptions.debugLevel' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'options.encoding' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'options.extensionDirs' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'options.failOnError' to build cache key: f6d7ed39fe24031e22d54f3fe65b901c
Appending input value fingerprint for 'options.fork' to build cache key: c06857e9ea338f3f3a24bb78f8fbdf6f
Appending input value fingerprint for 'options.forkOptions' to build cache key: 8d36acc9dcbda3eebf865b04f6eb5772
Appending input value fingerprint for 'options.forkOptions.executable' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'options.forkOptions.jvmArgs' to build cache key: 8222d82255460164427051d7537fa305
Appending input value fingerprint for 'options.javaModuleMainClass' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'options.javaModuleVersion' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'options.release' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'sourceCompatibility' to build cache key: de9fa2faa0f00ac6df74adbb7070f634
Appending input value fingerprint for 'targetCompatibility' to build cache key: de9fa2faa0f00ac6df74adbb7070f634
Appending input file fingerprints for 'classpath' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - COMPILE_CLASSPATH{EMPTY}
Appending input file fingerprints for 'options.annotationProcessorPath' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - CLASSPATH{EMPTY}
Appending input file fingerprints for 'options.bootstrapClasspath' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - COMPILE_CLASSPATH{EMPTY}
Appending input file fingerprints for 'options.sourcepath' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - RELATIVE_PATH{EMPTY}
Appending input file fingerprints for 'stableSources' to build cache key: f756ce8a66d9a09b740856b4f48c56be - RELATIVE_PATH{C:\Users\kengo\AppData\Local\Temp\3687353348111206190\src\main\java\Foo.java='Foo.java' / e368ce332db0ffcf59638d0f76f600f9}
Appending output property name to build cache key: destinationDirectory
Appending output property name to build cache key: options.generatedSourceOutputDirectory
Appending output property name to build cache key: options.headerOutputDirectory
Appending output property name to build cache key: previousCompilationData
Build cache key for task ':compileJava' is 6310fbd8db3535848fcbb3c8622d0351

> Task :processResources NO-SOURCE
> Task :classes UP-TO-DATE

> Task :spotbugsMain
Appending implementation to build cache key: com.github.spotbugs.snom.SpotBugsTask_Decorated@484879661599fa60f647abc3c56ca71c
Appending additional implementation to build cache key: com.github.spotbugs.snom.SpotBugsTask_Decorated@484879661599fa60f647abc3c56ca71c
Appending input value fingerprint for 'effort' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'enabledReports.$0' to build cache key: 317d37c046c7cf6d54899a3db0746af5
Appending input value fingerprint for 'enabledReports.$0.name' to build cache key: 0ccaa2f9c69d75ba8e24c44cf16ac4b7
Appending input value fingerprint for 'enabledReports.$0.required' to build cache key: f6d7ed39fe24031e22d54f3fe65b901c
Appending input value fingerprint for 'extraArgs' to build cache key: 8222d82255460164427051d7537fa305
Appending input value fingerprint for 'firstEnabledReport' to build cache key: 317d37c046c7cf6d54899a3db0746af5
Appending input value fingerprint for 'firstEnabledReport.name' to build cache key: 0ccaa2f9c69d75ba8e24c44cf16ac4b7
Appending input value fingerprint for 'firstEnabledReport.required' to build cache key: f6d7ed39fe24031e22d54f3fe65b901c
Appending input value fingerprint for 'ignoreFailures' to build cache key: c06857e9ea338f3f3a24bb78f8fbdf6f
Appending input value fingerprint for 'jvmArgs' to build cache key: 8222d82255460164427051d7537fa305
Appending input value fingerprint for 'maxHeapSize' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'omitVisitors' to build cache key: 8222d82255460164427051d7537fa305
Appending input value fingerprint for 'onlyAnalyze' to build cache key: 8222d82255460164427051d7537fa305
Appending input value fingerprint for 'release' to build cache key: f13b59d185c6ccc578fb0e600efd5f05
Appending input value fingerprint for 'reportLevel' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'showProgress' to build cache key: f6bd6b3389b872033d462029172c8612
Appending input value fingerprint for 'showStackTraces' to build cache key: c06857e9ea338f3f3a24bb78f8fbdf6f
Appending input value fingerprint for 'useAuxclasspathFile' to build cache key: f6d7ed39fe24031e22d54f3fe65b901c
Appending input value fingerprint for 'visitors' to build cache key: 8222d82255460164427051d7537fa305
Appending input file fingerprints for 'auxClassPaths' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - CLASSPATH{EMPTY}
Appending input file fingerprints for 'baselineFile' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - RELATIVE_PATH{EMPTY}
Appending input file fingerprints for 'classes' to build cache key: 7a122a53d23e86d7bf3fd6592542193d - RELATIVE_PATH{C:\Users\kengo\AppData\Local\Temp\3687353348111206190\build\classes\java\main\Foo.class='Foo.class' / c484cef8dc7adb60d69e8fa4ed392c79}
Appending input file fingerprints for 'excludeFilter' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - RELATIVE_PATH{EMPTY}
Appending input file fingerprints for 'includeFilter' to build cache key: 5fd1e7396e8de4cb5c23dc6aadd7787a - RELATIVE_PATH{EMPTY}
Appending input file fingerprints for 'sourceDirs' to build cache key: 40f298436a980717ef25fe273f5d467d - RELATIVE_PATH{C:\Users\kengo\AppData\Local\Temp\3687353348111206190\src\main\resources='resources' / MISSING, C:\Users\kengo\AppData\Local\Temp\3687353348111206190\src\main\java=IGNORED / DIR, C:\Users\kengo\AppData\Local\Temp\3687353348111206190\src\main\java\Foo.java='Foo.java' / 228f7a4f4ec018eaa6e7760527a8876a}
Appending output property name to build cache key: enabledReports.$0.outputLocation
Appending output property name to build cache key: firstEnabledReport.outputLocation
Build cache key for task ':spotbugsMain' is 3b7bcf70435f87dd980f3365cff4bdcc

BUILD SUCCESSFUL in 13s
2 actionable tasks: 1 executed, 1 from cache
Configuration cache entry stored.
```