### PR TITLE
Print path of report files instead of their URL, for better multi-platform support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,8 +9,8 @@ on:
       - master
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  sonar-and-semantic-release:
+    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
         gradle: ['7.0', '7.3.3']
@@ -24,15 +24,11 @@ jobs:
         distribution: 'temurin'
         java-version: 11
         cache: gradle
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '${{ steps.nvm.outputs.NVMRC }}'
+        node-version-file: '.nvmrc'
         cache: npm
-      if: matrix.gradle == '7.0'
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Build with Gradle
@@ -40,7 +36,7 @@ jobs:
         SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
       run: |
-        ./gradlew build --no-daemon -Dsnom.test.functional.gradle=${{ matrix.gradle }}
+        ./gradlew build --no-daemon
         echo Verifying the java version used in class files...
         cd build/classes/groovy/main
         javap -v com.github.spotbugs.snom.SpotBugsPlugin | grep -q 'major version: 52'
@@ -51,7 +47,6 @@ jobs:
         rm -rf build/libs/*.jar
         npm ci
         npx semantic-release
-      if: matrix.gradle == '7.0'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run SonarQube Scanner
@@ -59,12 +54,42 @@ jobs:
         if [ "$SONAR_LOGIN" != "" ]; then
           ./gradlew sonarqube -Dsonar.login=$SONAR_LOGIN --no-daemon
         fi
-      if: matrix.gradle == '7.0'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
     - uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: reports (Gradle ${{ matrix.gradle }})
+        name: reports
+        path: build/reports
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        gradle: ['7.0', '7.3.3']
+        os: ['ubuntu-latest', 'windows-latest']
+        exclude:
+          # used in the sonar-and-semantic-release job
+          - gradle: '7.3.3'
+            os: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: 11
+        cache: gradle
+    - name: Build with Gradle
+      env:
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      run: |
+        ./gradlew build --no-daemon "-Dsnom.test.functional.gradle=${{ matrix.gradle }}"
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: reports (Gradle ${{ matrix.gradle }} on ${{ matrix.os }})
         path: build/reports

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,4 +1,1 @@
 16
-
-# semantic-release v18.0.0 recommends to use 14.17 or above
-# https://github.com/semantic-release/semantic-release/releases/tag/v18.0.0

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/AndroidFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/AndroidFunctionalTest.groovy
@@ -110,7 +110,7 @@ buildscript {
 """
         runner.pluginClasspath.forEach({ file ->
             buildFile << """
-        classpath files('${file.absolutePath}')
+        classpath files('${file.toURI()}')
 """
         })
         buildFile << """
@@ -151,7 +151,7 @@ buildscript {
 """
         runner.pluginClasspath.forEach({ file ->
             buildFile << """
-        classpath files('${file.absolutePath}')
+        classpath files('${file.toURI()}')
 """
         })
         buildFile << """

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -79,7 +79,7 @@ spotbugs {
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
         assertTrue(result.getOutput().contains("-include"))
-        assertTrue(result.getOutput().contains(filter.getAbsolutePath()))
+        assertTrue(result.getOutput().contains(filter.getCanonicalPath()))
     }
 
     def "can use excludeFilter"() {
@@ -103,7 +103,7 @@ spotbugs {
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
         assertTrue(result.getOutput().contains("-exclude"))
-        assertTrue(result.getOutput().contains(filter.getAbsolutePath()))
+        assertTrue(result.getOutput().contains(filter.getCanonicalPath()))
     }
 
     def "can use baselineFile"() {
@@ -127,7 +127,7 @@ spotbugs {
         then:
         assertEquals(SUCCESS, result.task(":spotbugsMain").outcome)
         assertTrue(result.getOutput().contains("-excludeBugs"))
-        assertTrue(result.getOutput().contains(baseline.getAbsolutePath()))
+        assertTrue(result.getOutput().contains(baseline.getCanonicalPath()))
     }
 
     def "can use visitors"() {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -699,7 +699,7 @@ spotbugsMain {
         then:
         result.task(':spotbugsMain').outcome == TaskOutcome.FAILED
         result.output.contains('See the report at')
-        def expectedOutput = rootDir.toPath().resolve(Paths.get("build", "reports", "spotbugs", "main.xml")).toUri().toString()
+        def expectedOutput = rootDir.toPath().resolve(Paths.get("build", "reports", "spotbugs", "main.xml")).toFile().getCanonicalPath()
         result.output.contains(expectedOutput)
 
         where:

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
@@ -17,9 +17,7 @@ import com.github.spotbugs.snom.SpotBugsReport;
 import com.github.spotbugs.snom.SpotBugsTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import groovy.lang.Closure;
-import java.io.File;
-import java.net.URI;
-import java.nio.file.Path;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -144,12 +142,19 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
       List<String> reportPaths =
           params.getReports().get().stream()
               .map(RegularFile::getAsFile)
-              .map(File::toPath)
-              .map(Path::toUri)
-              .map(URI::toString)
+              .map(
+                  file -> {
+                    try {
+                      return file.getCanonicalPath();
+                    } catch (IOException e) {
+                      log.warn(
+                          "failed to compute a canonical path, use absolute path as a fallback", e);
+                      return file.getAbsolutePath();
+                    }
+                  })
               .collect(Collectors.toList());
       if (!reportPaths.isEmpty()) {
-        errorMessage += "See the report at: " + String.join(",", reportPaths);
+        errorMessage += "See the report at: " + String.join(", ", reportPaths);
       }
       throw new GradleException(errorMessage);
     }


### PR DESCRIPTION
Recently we introduced a defect that is caused only on the Windows platform (#614). We had a similar problem (#273) previously.
To avoid reproducing these problems, run workflows in PR not only on the Ubuntu platform but also on the Windows platform.

This PR also changes the report path from URL to canonical file path, because, on the Windows platform URL and absolute path may include short paths and it makes functional test unstable.

In URL the Windows platform may use a short path, and it makes the functional test unstable. 
It is also not useful for users, they need a full path but the printed URL is not.