### PR TITLE
Bump up the default SpotBugs to v4.7.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
       - run: git checkout HEAD^2
         if: ${{ github.event_name == 'pull_request' }}
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         gradle: ['7.0', '7.3.3']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 11
@@ -28,7 +28,7 @@ jobs:
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '${{ steps.nvm.outputs.NVMRC }}'
         cache: npm
@@ -63,7 +63,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: reports (Gradle ${{ matrix.gradle }})

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
@@ -21,7 +21,7 @@ jobs:
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
           cache: npm

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Configure `spotbugsPlugin` to apply any SpotBugs plugin:
 
 ```groovy
 dependencies {
-    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.11.0'
+    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0'
 }
 ```
 
@@ -86,7 +86,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.11.0")
+    spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0")
 }
 ```
 </details>
@@ -95,7 +95,7 @@ Configure `spotbugs` to choose your favorite SpotBugs version:
 
 ```groovy
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.5.3'
+    spotbugs 'com.github.spotbugs:spotbugs:4.7.0'
 }
 ```
 
@@ -104,7 +104,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    spotbugs("com.github.spotbugs:spotbugs:4.5.3")
+    spotbugs("com.github.spotbugs:spotbugs:4.7.0")
 }
 ```
 </details>
@@ -160,7 +160,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 |Gradle Plugin|SpotBugs|
 |-----:|-----:|
-| 5.0.7| 4.6.0|
+| 5.0.7| 4.7.0|
 | 5.0.4| 4.5.3|
 | 5.0.3| 4.5.2|
 | 5.0.2| 4.5.1|

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.13.1'
-    spotBugsVersion = '4.6.0'
+    spotBugsVersion = '4.7.0'
     slf4jVersion = '1.8.0-beta4'
     androidGradlePluginVersion = '7.1.3'
 }

--- a/gradle/HEADER.txt
+++ b/gradle/HEADER.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 SpotBugs team
+ * Copyright $YEAR SpotBugs team
  *
  * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Today the SpotBugs made its latest release v4.7.0:

https://github.com/spotbugs/spotbugs/releases/tag/4.7.0

This PR will bump up the default SpotBugs to this release. Also updates a few things in the build workflow, to keep the codebase secure and updated.