### PR TITLE
fix: SpotBugsTask should be cacheable even when no report is configured by user

### DIFF
--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -28,7 +28,8 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SkipWhenEmpty
 
 import org.gradle.api.Action;
@@ -51,6 +52,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
+import org.gradle.internal.enterprise.test.FileProperty
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.util.ClosureBackedAction
@@ -300,6 +302,12 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
     @Optional
     abstract Property<JavaLauncher> getLauncher()
 
+    /**
+     * A file that lists class files and jar files to analyse.
+     */
+    @OutputFile
+    abstract RegularFileProperty analyseClassFile
+
     @Inject
     SpotBugsTask(ObjectFactory objects, WorkerExecutor workerExecutor) {
         this.workerExecutor = Objects.requireNonNull(workerExecutor);
@@ -368,6 +376,9 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         spotbugsClasspath = project.layout.files {
             spotbugsSlf4j.files + configuration.files
         }
+
+        def file = new File(project.buildDir, this.name + "-analyse-class-file.txt")
+        analyseClassFile = project.objects.fileProperty().fileValue(file)
     }
 
     /**

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -306,7 +306,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
      * A file that lists class files and jar files to analyse.
      */
     @OutputFile
-    final abstract RegularFileProperty analyseClassFile
+    abstract RegularFileProperty analyseClassFile
 
     @Inject
     SpotBugsTask(ObjectFactory objects, WorkerExecutor workerExecutor) {
@@ -376,9 +376,6 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
         spotbugsClasspath = project.layout.files {
             spotbugsSlf4j.files + configuration.files
         }
-
-        def file = new File(project.buildDir, this.name + "-analyse-class-file.txt")
-        analyseClassFile = project.objects.fileProperty().fileValue(file)
     }
 
     /**
@@ -414,6 +411,9 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
 
         this.enableWorkerApi = enableWorkerApi
         this.enableHybridWorker = enableHybridWorker
+
+        def file = new File(project.buildDir, this.name + "-analyse-class-file.txt")
+        analyseClassFile.set(file)
     }
 
 

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -306,7 +306,7 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
      * A file that lists class files and jar files to analyse.
      */
     @OutputFile
-    abstract RegularFileProperty analyseClassFile
+    final abstract RegularFileProperty analyseClassFile
 
     @Inject
     SpotBugsTask(ObjectFactory objects, WorkerExecutor workerExecutor) {

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsTask.groovy
@@ -306,7 +306,8 @@ abstract class SpotBugsTask extends DefaultTask implements VerificationTask {
      * A file that lists class files and jar files to analyse.
      */
     @OutputFile
-    abstract RegularFileProperty analyseClassFile
+    @NonNull
+    abstract RegularFileProperty getAnalyseClassFile()
 
     @Inject
     SpotBugsTask(ObjectFactory objects, WorkerExecutor workerExecutor) {

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -168,7 +168,7 @@ public abstract class SpotBugsRunner {
     try {
       Iterable<String> lines =
           files.filter(File::exists).getFiles().stream().map(File::getAbsolutePath)::iterator;
-      Files.write(file.toPath(), lines, StandardCharsets.UTF_8, StandardOpenOption.WRITE);
+      Files.write(file.toPath(), lines, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
     } catch (IOException e) {
       throw new GradleException("Fail to generate the text file to list target .class files", e);
     }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunner.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
-import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,8 +122,11 @@ public abstract class SpotBugsRunner {
     args.add(task.getProjectName().get());
     args.add("-release");
     args.add(task.getRelease().get());
+
+    File file = task.getAnalyseClassFile().getAsFile().get();
+    generateFile(task.getClasses(), task.getAnalyseClassFile().getAsFile().get());
     args.add("-analyzeFromFile");
-    args.add(generateFile(task.getClasses(), task).getAbsolutePath());
+    args.add(file.getAbsolutePath());
 
     args.addAll(task.getExtraArgs().getOrElse(Collections.emptyList()));
     log.debug("Arguments for SpotBugs are generated: {}", args);
@@ -162,14 +164,11 @@ public abstract class SpotBugsRunner {
     }
   }
 
-  private File generateFile(FileCollection files, Task task) {
+  private void generateFile(FileCollection files, File file) {
     try {
-      File file = File.createTempFile("spotbugs-gradle-plugin", ".txt", task.getTemporaryDir());
       Iterable<String> lines =
           files.filter(File::exists).getFiles().stream().map(File::getAbsolutePath)::iterator;
       Files.write(file.toPath(), lines, StandardCharsets.UTF_8, StandardOpenOption.WRITE);
-
-      return file;
     } catch (IOException e) {
       throw new GradleException("Fail to generate the text file to list target .class files", e);
     }


### PR DESCRIPTION
Treat the text file generated by our tasks, to keep the task cacheable even when it outputs no report files.

close #630

When we merge this PR, please squash-and-merge because the commit history is little bit noisy.