### PR TITLE
Update SpotBugs to work with Gradle 8+

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -699,7 +699,7 @@ spotbugsMain {
         then:
         result.task(':spotbugsMain').outcome == TaskOutcome.FAILED
         result.output.contains('See the report at')
-        def expectedOutput = rootDir.toPath().resolve(Paths.get("build", "reports", "spotbugs", "main.xml")).toUri().toString()
+        def expectedOutput = rootDir.toPath().toRealPath().resolve(Paths.get("build", "reports", "spotbugs", "main.xml")).toUri().toString()
         result.output.contains(expectedOutput)
 
         where:

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -51,7 +51,6 @@ public abstract class SpotBugsReport
   public abstract String toCommandLineOption();
 
   /** @deprecated use {@link #getOutputLocation()} instead. */
-  @Override
   @Deprecated
   @ReplacedBy("getRequired")
   public File getDestination() {
@@ -77,7 +76,6 @@ public abstract class SpotBugsReport
 
   /** @deprecated use {@link #getRequired()} instead. */
   @Deprecated
-  @Override
   @ReplacedBy("getRequired")
   public boolean isEnabled() {
     return isRequired.get();
@@ -85,28 +83,24 @@ public abstract class SpotBugsReport
 
   /** @deprecated use {@code getRequired().set(value)} instead. */
   @Deprecated
-  @Override
   public void setEnabled(boolean b) {
     isRequired.set(b);
   }
 
   /** @deprecated use {@code getRequired().set(provider)} instead. */
   @Deprecated
-  @Override
   public void setEnabled(Provider<Boolean> provider) {
     isRequired.set(provider);
   }
 
   /** @deprecated use {@code getOutputLocation().set(file)} instead. */
   @Deprecated
-  @Override
   public void setDestination(File file) {
     destination.set(file);
   }
 
   /** @deprecated use {@code getOutputLocation().set(provider)} instead. */
   @Deprecated
-  @Override
   public void setDestination(Provider<File> provider) {
     destination.set(this.task.getProject().getLayout().file(provider));
   }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -21,7 +21,6 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.CustomizableHtmlReport;
@@ -52,7 +51,7 @@ public abstract class SpotBugsReport
 
   /** @deprecated use {@link #getOutputLocation()} instead. */
   @Deprecated
-  @ReplacedBy("getRequired")
+  @Internal
   public File getDestination() {
     return destination.get().getAsFile();
   }
@@ -76,7 +75,7 @@ public abstract class SpotBugsReport
 
   /** @deprecated use {@link #getRequired()} instead. */
   @Deprecated
-  @ReplacedBy("getRequired")
+  @Internal
   public boolean isEnabled() {
     return isRequired.get();
   }

--- a/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
+++ b/src/main/groovy/com/github/spotbugs/snom/SpotBugsReport.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.CustomizableHtmlReport;
@@ -52,6 +53,7 @@ public abstract class SpotBugsReport
   /** @deprecated use {@link #getOutputLocation()} instead. */
   @Override
   @Deprecated
+  @ReplacedBy("getRequired")
   public File getDestination() {
     return destination.get().getAsFile();
   }
@@ -76,6 +78,7 @@ public abstract class SpotBugsReport
   /** @deprecated use {@link #getRequired()} instead. */
   @Deprecated
   @Override
+  @ReplacedBy("getRequired")
   public boolean isEnabled() {
     return isRequired.get();
   }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForHybrid.java
@@ -140,7 +140,7 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
         return;
       }
 
-      String errorMessage = "Verification failed: SpotBugs ended with exit code " + exitValue;
+      String errorMessage = "Verification failed: SpotBugs ended with exit code " + exitValue + ".";
       List<String> reportPaths =
           params.getReports().get().stream()
               .map(RegularFile::getAsFile)
@@ -149,7 +149,7 @@ class SpotBugsRunnerForHybrid extends SpotBugsRunner {
               .map(URI::toString)
               .collect(Collectors.toList());
       if (!reportPaths.isEmpty()) {
-        errorMessage += "See the report at: " + String.join(",", reportPaths);
+        errorMessage += " See the report at: " + String.join(",", reportPaths);
       }
       throw new GradleException(errorMessage);
     }


### PR DESCRIPTION
Gradle 8 will be dropping some methods from the `ConfigurableReport` class.  By removing the `@Override marker` from some methods and marking getters as `@ReplacedBy`, this will allow a version of SpotBugs to be built which will work with Gradle 7 or 8, and can be smoke tested (internally in the Gradle build) against either version of Gradle.

After Gradle 8.0 is released, a subsequent version of SpotBugs can then fully remove these methods and update its wrapper to use Gradle 8+.

This is an incremental step towards https://github.com/spotbugs/spotbugs-gradle-plugin/issues/600