### PR TITLE
fix: bump default spotbugs version from 4.7.1 to 4.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 | Gradle Plugin | SpotBugs |
 |--------------:|---------:|
-|        5.0.13 |    4.7.2 |
+|        5.0.12 |    4.7.2 |
 |         5.0.9 |    4.7.1 |
 |         5.0.7 |    4.7.0 |
 |         5.0.4 |    4.5.3 |

--- a/README.md
+++ b/README.md
@@ -158,24 +158,25 @@ By default, this Gradle Plugin uses the SpotBugs version listed in this table.
 
 You can change SpotBugs version by [the `toolVersion` property of the spotbugs extension](https://spotbugs-gradle-plugin.netlify.com/com/github/spotbugs/snom/spotbugsextension#toolVersion) or the `spotbugs` configuration.
 
-|Gradle Plugin|SpotBugs|
-|-----:|-----:|
-| 5.0.9| 4.7.1|
-| 5.0.7| 4.7.0|
-| 5.0.4| 4.5.3|
-| 5.0.3| 4.5.2|
-| 5.0.2| 4.5.1|
-| 4.7.10| 4.5.0|
-| 4.7.8| 4.4.2|
-| 4.7.5| 4.4.1|
-| 4.7.3| 4.4.0|
-| 4.7.2| 4.3.0|
-| 4.6.1| 4.2.1|
-| 4.5.0| 4.1.1|
-| 4.4.4| 4.0.6|
-| 4.4.2| 4.0.5|
-| 4.0.7| 4.0.2|
-| 4.0.0| 4.0.0|
+| Gradle Plugin | SpotBugs |
+|--------------:|---------:|
+|        5.0.10 |    4.7.2 |
+|         5.0.9 |    4.7.1 |
+|         5.0.7 |    4.7.0 |
+|         5.0.4 |    4.5.3 |
+|         5.0.3 |    4.5.2 |
+|         5.0.2 |    4.5.1 |
+|        4.7.10 |    4.5.0 |
+|         4.7.8 |    4.4.2 |
+|         4.7.5 |    4.4.1 |
+|         4.7.3 |    4.4.0 |
+|         4.7.2 |    4.3.0 |
+|         4.6.1 |    4.2.1 |
+|         4.5.0 |    4.1.1 |
+|         4.4.4 |    4.0.6 |
+|         4.4.2 |    4.0.5 |
+|         4.0.7 |    4.0.2 |
+|         4.0.0 |    4.0.0 |
 
 ### Refer the version in the build script
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 | Gradle Plugin | SpotBugs |
 |--------------:|---------:|
-|        5.0.10 |    4.7.2 |
+|        5.0.13 |    4.7.2 |
 |         5.0.9 |    4.7.1 |
 |         5.0.7 |    4.7.0 |
 |         5.0.4 |    4.5.3 |

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 ext {
     errorproneVersion = '2.15.0'
     spotBugsVersion = '4.7.2'
-    slf4jVersion = '1.8.0-beta4'
+    slf4jVersion = '2.0.0'
     androidGradlePluginVersion = '7.2.2'
 }
 


### PR DESCRIPTION
Thanks for merging #782!

When we bump up the dependency on spotbugs-core, it is better to:

1. update the README.md to tell the mapping between versions of gradle-plugin and spotbugs-core,
2. trigger a release by make a commit with `fix:` prefix

Please merge this PR by `squash and merge` and make sure its commit message starts with `fix:` then next release will be made by Gradle automatic.