### PR TITLE
fix: bump default spotbugs version from 4.7.2 to 4.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 | Gradle Plugin | SpotBugs |
 |--------------:|---------:|
+|        5.0.13 |    4.7.3 |
 |        5.0.12 |    4.7.2 |
 |         5.0.9 |    4.7.1 |
 |         5.0.7 |    4.7.0 |

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 ext {
     errorproneVersion = '2.16'
-    spotBugsVersion = '4.7.2'
+    spotBugsVersion = '4.7.3'
     slf4jVersion = '2.0.0'
     androidGradlePluginVersion = '7.3.0'
 }


### PR DESCRIPTION
Hey,
there is a new version of spotbugs available (4.7.3) https://github.com/spotbugs/spotbugs/releases/tag/4.7.3 which updates the common-text dependency from 1.9 to 1.10, due it is vulnerable.

This PR just updates the dependency to the latest version.