### PR TITLE
Fix broken builds on the GitHub Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,12 +37,12 @@ dependencies {
     testImplementation("com.tngtech.archunit:archunit:1.0.0")
 }
 
-val signingKey = providers.environmentVariable("SIGNING_KEY")
-val signingPassword = providers.environmentVariable("SIGNING_PASSWORD")
+val signingKey: String? = System.getenv("SIGNING_KEY")
+val signingPassword: String? = System.getenv("SIGNING_PASSWORD")
 
 signing {
-    if (signingKey.isPresent && signingPassword.isPresent) {
-        useInMemoryPgpKeys(signingKey.get(), signingPassword.get())
+    if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
         sign(configurations.archives.get())
     } else {
         logger.warn("The signing key and password are null. This can be ignored if this is a pull request.")


### PR DESCRIPTION
By #799 I replaced Groovy-based build scripts with Kotlin Script, and it introduced a problem that makes builds on the GitHub Actions failing.

This PR fixes this problem, by using native `System.getenv()` instead of provider-based API. It was my mistake, I should not use provider-based API if I resolve its value during the configuration phase.