### PR TITLE
chore: bump com.gradle.plugin-publish to 1.2.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.18.0")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
-    implementation("com.gradle.publish:plugin-publish-plugin:0.21.0")
+    implementation("com.gradle.publish:plugin-publish-plugin:1.2.0")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")
 }
 


### PR DESCRIPTION
Fixes https://github.com/spotbugs/spotbugs-gradle-plugin/issues/888