### PR TITLE
fix: Task does not fail if report generation fails

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/Issue909.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/Issue909.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 SpotBugs team
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.spotbugs.snom
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * @see <a href="https://github.com/spotbugs/spotbugs-gradle-plugin/issues/909">GitHub Issues</a>
+ */
+class Issue909 extends Specification {
+    Path rootDir
+    Path buildFile
+
+    def setup() {
+        rootDir = Files.createTempDirectory("spotbugs-gradle-plugin")
+        buildFile = rootDir.resolve("build.gradle")
+        buildFile.toFile() << """
+plugins {
+  id "java"
+  id "com.github.spotbugs"
+}
+repositories {
+  mavenCentral()
+}
+tasks.spotbugsMain {
+    reports {
+        html {
+            required = true
+            stylesheet = resources.text.fromString("I am not valid XSL")
+        }
+    }
+}
+        """
+        Path sourceDir = rootDir.resolve("src").resolve("main").resolve("java")
+        sourceDir.toFile().mkdirs()
+        Path sourceFile = sourceDir.resolve("Foo.java")
+        sourceFile.toFile() << """
+public class Foo {
+    public static void main(String... args) {
+        System.out.println("Hello, SpotBugs!");
+    }
+}
+"""
+    }
+
+    def "can generate spotbugs.html with stylesheet"() {
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(rootDir.toFile())
+                .withArguments('spotbugsMain')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        TaskOutcome.FAILED == result.task(":spotbugsMain").outcome
+    }
+}

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/Issue909.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/Issue909.groovy
@@ -13,7 +13,6 @@
  */
 package com.github.spotbugs.snom
 
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
@@ -60,13 +59,13 @@ public class Foo {
 """
     }
 
-    def "can generate spotbugs.html with stylesheet"() {
+    def "cannot generate HTML report if invalid XSL is provided"() {
         when:
         def result = GradleRunner.create()
                 .withProjectDir(rootDir.toFile())
                 .withArguments('spotbugsMain')
                 .withPluginClasspath()
-                .build()
+                .buildAndFail()
 
         then:
         TaskOutcome.FAILED == result.task(":spotbugsMain").outcome

--- a/src/main/groovy/com/github/spotbugs/snom/internal/OutputScanner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/OutputScanner.java
@@ -1,0 +1,37 @@
+package com.github.spotbugs.snom.internal;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Monitors the stdout of forked process, and report when it contains some problems reported by
+ * SpotBugs core.
+ */
+class OutputScanner extends FilterOutputStream {
+  private final StringBuilder builder = new StringBuilder();
+  private boolean failedToReport = false;
+
+  public OutputScanner(OutputStream out) {
+    super(out);
+  }
+
+  boolean isFailedToReport() {
+    return failedToReport;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    super.write(b);
+    builder.append((char)b);
+    if (b == '\n') {
+      String line = builder.toString();
+      System.err.println("line:" + line);
+      if (line.contains("Could not generate HTML output")) {
+        failedToReport = true;
+      }
+
+      builder.delete(0, builder.length());
+    }
+  }
+}

--- a/src/main/groovy/com/github/spotbugs/snom/internal/OutputScanner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/OutputScanner.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2023 SpotBugs team
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.spotbugs.snom.internal;
 
 import java.io.FilterOutputStream;
@@ -23,7 +36,7 @@ class OutputScanner extends FilterOutputStream {
   @Override
   public void write(int b) throws IOException {
     super.write(b);
-    builder.append((char)b);
+    builder.append((char) b);
     if (b == '\n') {
       String line = builder.toString();
       System.err.println("line:" + line);

--- a/src/main/groovy/com/github/spotbugs/snom/internal/OutputScanner.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/OutputScanner.java
@@ -13,16 +13,18 @@
  */
 package com.github.spotbugs.snom.internal;
 
+import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Monitors the stdout of forked process, and report when it contains some problems reported by
  * SpotBugs core.
  */
 class OutputScanner extends FilterOutputStream {
-  private final StringBuilder builder = new StringBuilder();
+  private final ByteArrayOutputStream builder = new ByteArrayOutputStream();
   private boolean failedToReport = false;
 
   public OutputScanner(OutputStream out) {
@@ -34,17 +36,23 @@ class OutputScanner extends FilterOutputStream {
   }
 
   @Override
+  public void write(byte @NotNull [] b, int off, int len) throws IOException {
+    super.write(b, off, len);
+    builder.write(b, off, len);
+  }
+
+  @Override
   public void write(int b) throws IOException {
     super.write(b);
-    builder.append((char) b);
+    builder.write(b);
+
     if (b == '\n') {
       String line = builder.toString();
-      System.err.println("line:" + line);
       if (line.contains("Could not generate HTML output")) {
         failedToReport = true;
       }
 
-      builder.delete(0, builder.length());
+      builder.reset();
     }
   }
 }

--- a/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
+++ b/src/main/groovy/com/github/spotbugs/snom/internal/SpotBugsRunnerForWorker.java
@@ -40,6 +40,7 @@ import org.gradle.workers.WorkerExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
 public class SpotBugsRunnerForWorker extends SpotBugsRunner {
   private final Logger log = LoggerFactory.getLogger(SpotBugsRunnerForWorker.class);
   private final WorkerExecutor workerExecutor;


### PR DESCRIPTION
Monitor the output from SpotBugs, and make the task failed if it contains related warning.

close #909