### PR TITLE
ci: configure semantic release on the v6 branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - v6
   pull_request:
     branches:
       - master
+      - v6
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "branches": [
       {
         "name": "master"
+      },
+      {
+        "channel": "beta",
+        "name": "v6",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
refs https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#pre-release-branches