### PR TITLE
build: use JVM Toolchains to pin the JDK version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,9 @@ plugins {
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 group = "com.github.spotbugs.snom"


### PR DESCRIPTION
In the current state, it is essential for the project to be built and tested with JDK 11.
Otherwise either errorprone wouldn't work or tests would fail. This constraint is currently undocumented.

With this commit, we use [Gradle JVM Toolchains](https://docs.gradle.org/current/userguide/toolchains.html)
to pin the JDK that is used to test/build the project to JDK 11. If JDK 11 is already used, nothing happens.
Otherwise, a JDK 11 is downloaded and installed on the users machine.
