### PR TITLE
[tests] Add spock ignoreIf not java 11 to tests that fail on newer jdks

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -15,6 +15,7 @@ package com.github.spotbugs.snom
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.IgnoreIf
 
 import java.nio.file.Files
 
@@ -118,6 +119,7 @@ class CacheabilityFunctionalTest extends BaseFunctionalTest {
     /**
      * @see <a href="https://github.com/spotbugs/spotbugs-gradle-plugin/issues/914">GitHub Issues</a>
      */
+    @IgnoreIf({ !jvm.java11 })
     def 'spotbugsMain is cacheable even if a stylesheet is set as String for the HTML report'() {
         given:
         def buildFile = new File(rootDir, "build.gradle")

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -14,6 +14,7 @@
 package com.github.spotbugs.snom
 
 import org.gradle.testkit.runner.BuildResult
+import spock.lang.IgnoreIf
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -205,6 +206,7 @@ spotbugs {
         result.getOutput().contains("-high")
     }
 
+    @IgnoreIf({ !jvm.java11 })
     def "can use toolVersion to set the SpotBugs version"() {
         setup:
         buildFile << """
@@ -221,6 +223,7 @@ spotbugs {
         result.output.contains("SpotBugs 4.0.0-beta4") || result.output.contains("spotbugs-4.0.0-beta4.jar")
     }
 
+    @IgnoreIf({ !jvm.java11 })
     def "can use toolVersion to get the SpotBugs version"() {
         setup:
         buildFile << """

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/KotlinBuildScriptFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/KotlinBuildScriptFunctionalTest.groovy
@@ -14,6 +14,7 @@
 package com.github.spotbugs.snom
 
 import org.gradle.testkit.runner.BuildResult
+import spock.lang.IgnoreIf
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -99,6 +100,7 @@ dependencies {
         !result.output.contains("Trying to add already registered factory")
     }
 
+    @IgnoreIf({ !jvm.java11 })
     def "can use the specified SpotBugs version"() {
         setup:
         buildFile << """
@@ -136,6 +138,7 @@ tasks.spotbugsMain {
         report.isFile()
     }
 
+    @IgnoreIf({ !jvm.java11 })
     def "can use toolVersion to get the SpotBugs version"() {
         setup:
         buildFile << """

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/MultiProjectFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/MultiProjectFunctionalTest.groovy
@@ -16,6 +16,7 @@ package com.github.spotbugs.snom
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -105,6 +106,7 @@ subprojects {
         result.output.contains("spotbugs-4.0.0-RC1.jar")
     }
 
+    @IgnoreIf({ !jvm.java11 })
     def "can use toolVersion in the subproject"() {
         setup:
         subBuildFile << """

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -15,6 +15,7 @@ package com.github.spotbugs.snom
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import java.nio.file.Paths
@@ -73,6 +74,7 @@ public class Foo {
         result.output.contains("spotbugsTest - Run SpotBugs analysis for the source set 'test'")
     }
 
+    @IgnoreIf({ !jvm.java11 })
     def "can use the specified SpotBugs version"() {
         setup:
         buildFile << """


### PR DESCRIPTION
Be very explicit on tests compatibility.  Sure tool chains can be used but it hides direct fact these are not compatible.  So lets be very clear on these.