### PR TITLE
test: tweak common test flags

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/BaseFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/BaseFunctionalTest.groovy
@@ -29,7 +29,7 @@ abstract class BaseFunctionalTest extends Specification {
         return new TestGradleRunner()
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(rootDir)
-                .withArguments('--info', '--stacktrace')
+                .withArguments('--info', '--stacktrace', '--warning-mode=fail')
                 .forwardOutput()
                 .withPluginClasspath()
     }

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/BaseFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/BaseFunctionalTest.groovy
@@ -29,7 +29,7 @@ abstract class BaseFunctionalTest extends Specification {
         return new TestGradleRunner()
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(rootDir)
-                .withArguments('--debug', '--stacktrace')
+                .withArguments('--info', '--stacktrace')
                 .forwardOutput()
                 .withPluginClasspath()
     }

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/BaseFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/BaseFunctionalTest.groovy
@@ -30,6 +30,7 @@ abstract class BaseFunctionalTest extends Specification {
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(rootDir)
                 .withArguments('--info', '--stacktrace', '--warning-mode=fail')
+                .withTestKitDir(testKitDir)
                 .forwardOutput()
                 .withPluginClasspath()
     }
@@ -44,5 +45,13 @@ abstract class BaseFunctionalTest extends Specification {
         DefaultGradleRunner withArguments(String... arguments) {
             return withArguments(Arrays.asList(arguments))
         }
+    }
+
+    private static File getTestKitDir() {
+        def gradleUserHome = System.getenv("GRADLE_USER_HOME")
+        if (!gradleUserHome) {
+            gradleUserHome = new File(System.getProperty("user.home"), ".gradle").absolutePath
+        }
+        return new File(gradleUserHome, "testkit")
     }
 }

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/CacheabilityFunctionalTest.groovy
@@ -189,7 +189,7 @@ class CacheabilityFunctionalTest extends BaseFunctionalTest {
 
         settingsFile << '''
             |plugins {
-            |    id "com.gradle.enterprise" version "3.6.4"
+            |    id "com.gradle.enterprise" version "3.16"
             |}
             |gradleEnterprise {
             |    buildScan {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -118,7 +118,7 @@ spotbugs {
 }"""
         when:
         def result = gradleRunner
-                .withArguments('spotbugsMain')
+                .withArguments('--debug', 'spotbugsMain')
                 .build()
 
         then:
@@ -133,7 +133,7 @@ spotbugs {
 }"""
         when:
         def result = gradleRunner
-                .withArguments('spotbugsMain')
+                .withArguments('--debug', 'spotbugsMain')
                 .build()
 
         then:
@@ -148,7 +148,7 @@ spotbugs {
 }"""
         when:
         def result = gradleRunner
-                .withArguments('spotbugsMain')
+                .withArguments('--debug', 'spotbugsMain')
                 .build()
 
         then:
@@ -238,7 +238,7 @@ dependencies {
 }"""
         when:
         BuildResult result = gradleRunner
-                .withArguments(":spotbugsMain")
+                .withArguments('--debug', ":spotbugsMain")
                 .build()
 
         then:

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/KotlinBuildScriptFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/KotlinBuildScriptFunctionalTest.groovy
@@ -161,7 +161,7 @@ dependencies {
 """
         when:
         BuildResult result = gradleRunner
-                .withArguments(":spotbugsMain")
+                .withArguments('--debug', ":spotbugsMain")
                 .build()
 
         then:

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/MultiProjectFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/MultiProjectFunctionalTest.groovy
@@ -77,7 +77,7 @@ repositories {
     def "can use project name of sub project"() {
         when:
         def result = gradleRunner
-                .withArguments(':sub:spotbugsMain')
+                .withArguments('--debug', ':sub:spotbugsMain')
                 .build()
 
         then:
@@ -98,7 +98,7 @@ subprojects {
 
         when:
         def result = gradleRunner
-                .withArguments(':sub:spotbugsMain')
+                .withArguments('--debug', ':sub:spotbugsMain')
                 .build()
 
         then:

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -550,7 +550,7 @@ public class SimpleTest {
 
         when:
         BuildResult result = gradleRunner
-                .withArguments('--debug', "spotbugsMain", "spotbugsTest", '--parallel')
+                .withArguments('--debug', '--parallel', "spotbugsMain", "spotbugsTest")
                 .build()
 
         then:

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/StandardFunctionalTest.groovy
@@ -486,7 +486,7 @@ public class MyFoo {
 
         when:
         BuildResult result = gradleRunner
-                .withArguments("spotbugsMain")
+                .withArguments('--debug', "spotbugsMain")
                 .build()
 
         then:
@@ -550,7 +550,7 @@ public class SimpleTest {
 
         when:
         BuildResult result = gradleRunner
-                .withArguments("spotbugsMain", "spotbugsTest", '--parallel')
+                .withArguments('--debug', "spotbugsMain", "spotbugsTest", '--parallel')
                 .build()
 
         then:


### PR DESCRIPTION
- `--debug` is a little annoying, replace it with `--info`.
- Enable '--warning-mode=fail' to check warnings in tests.
- Bump GE plugin in tests due to some warnings.
- Reuse testKitDir, to share test dependencies cache for speeding up clean build.