### PR TITLE
fix: Gradle plugin should require JVM 8 but require JVM 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         fetch-depth: 0
     - uses: webiny/action-conventional-commits@v1.1.0
+      if: github.event_name == 'pull_request'
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - uses: webiny/action-conventional-commits@v1.1.0
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ You can change SpotBugs version by [the `toolVersion` property of the spotbugs e
 
 | Gradle Plugin | SpotBugs |
 |--------------:|---------:|
+|         6.0.3 |    4.8.3 |
 |         6.0.0 |    4.8.2 |
 |         5.2.5 |    4.8.2 |
 |         5.2.3 |    4.8.1 |
@@ -209,7 +210,7 @@ dependencies {
 
 ## Development
 ### Setup
-* development requires java 11 or higher to be installed
+* development requires java 17 or higher to be installed
 * The CI server uses `ubuntu-latest` docker image, but you should be able to develop on any linux/unix based OS.
 * before creating commits
   * read https://www.conventionalcommits.org/en

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
Our commit hook　is not enough to make commits following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so introduce `webiny/action-conventional-commits` to verify during the workflow.

This PR also adds a commit with `fix:` prefix, so it will trigger a release for v6.0.4.