### PR TITLE
docs: Update README.md - fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ tasks.spotbugsMain {
 
 <details>
 <summary>with Groovy DSL</summary>
+    
 ```groovy
 // Example to configure HTML report
 spotbugsMain {


### PR DESCRIPTION
Documentation doesn't display property.

![Changes Readme](https://github.com/spotbugs/spotbugs-gradle-plugin/assets/45349070/9a95ad2b-4cb9-42ba-97db-de9ac6ed70c3)
