### PR TITLE
ci: avoid conflict of uploaded artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,5 +63,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: reports (Gradle ${{ matrix.gradle }})
+        name: reports (Gradle ${{ matrix.gradle }}, ${{ matrix.os }})
         path: build/reports


### PR DESCRIPTION
#1081 failed due to a conflict of uploaded artifacts, which was introduced by #1006.
This PR will resolve this issue by adding an OS identifier to the name of uploaded artifacts.