### PR TITLE
handle reports as output of SpotBugsTask

### DIFF
--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
@@ -311,6 +311,8 @@ abstract class SpotBugsTask : DefaultTask(), VerificationTask {
                 "text" -> objects.newInstance(SpotBugsTextReport::class.java, name, objects, this)
                 "sarif" -> objects.newInstance(SpotBugsSarifReport::class.java, name, objects, this)
                 else -> throw InvalidUserDataException("$name is invalid as the report name")
+            }.also {
+                (outputs as org.gradle.api.tasks.TaskOutputs).file(it.outputLocation)
             }
         }
         description = "Run SpotBugs analysis."


### PR DESCRIPTION
close #1077

I could not find the difference between the previous Groovy implementation and the current Kotlin implementation. However, it is easy to fix the reported issue; just register the report file as output of the `SpotBugsTask`.