### PR TITLE
Additionally run on macos and only run javap on linux as not really needed

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,8 +36,8 @@ jobs:
       with:
         arguments: build -Psnom.test.functional.gradle=${{ matrix.gradle }} --scan
     - run: |
-        echo $PATH
-        echo Verifying the java version used in class files...
+        echo "$PATH"
+        echo "Verifying the java version used in class files..."
         cd build/classes/kotlin/main
         javap -v com.github.spotbugs.snom.SpotBugsPlugin | grep -q 'major version: 52'
     - name: Run Semantic Release

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,9 @@ jobs:
       uses: gradle/actions/setup-gradle@v3
       with:
         arguments: build -Psnom.test.functional.gradle=${{ matrix.gradle }} --scan
-    - run: |
+    - name: Verify class files
+      if: matrix.os == 'ubuntu-latest'
+      run: |
         echo "$PATH"
         echo "Verifying the java version used in class files..."
         cd build/classes/kotlin/main

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         gradle: [ '7.6.3', '8.1', 'current' ]
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         arguments: build -Psnom.test.functional.gradle=${{ matrix.gradle }} --scan
     - run: |
+        echo $PATH
         echo Verifying the java version used in class files...
         cd build/classes/kotlin/main
         javap -v com.github.spotbugs.snom.SpotBugsPlugin | grep -q 'major version: 52'


### PR DESCRIPTION
note: The windows update done on github no longer has PATH set.  Thus the failure.  I don't see much value in javap here.  I think gradle should be ensuring its setup correctly not some post action to confirm.  As such, rather than trying to fix the path (note it runs on macos ok with path), just make it run on linux only for that step as good enough.