### PR TITLE
build: don't ignore API checking for internal package

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,13 +38,6 @@ dependencies {
 val signingKey: String? = providers.environmentVariable("SIGNING_KEY").orNull
 val signingPassword: String? = providers.environmentVariable("SIGNING_PASSWORD").orNull
 
-apiValidation {
-    ignoredPackages += listOf(
-        // Ignore the following packages because they are not public API.
-        "com.github.spotbugs.snom.internal",
-    )
-}
-
 signing {
     if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
         useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
We should mark all internal APIs `internal` and let BCV check visibilities.

This reverts the change in https://github.com/spotbugs/spotbugs-gradle-plugin/pull/1064#discussion_r1418501984.