### PR TITLE
Update gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle: [ '7.6.4', '8.1', 'current' ]
+        gradle: [ '7.6.4', '8.11.1' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
drop having gradle 8.1 and 8.11.1, just use 8.11.1 as its wasting our cache otherwise and provides no point.