### PR TITLE
feat: Add an extension property to decouple tasks from check

### DIFF
--- a/api/spotbugs-gradle-plugin.api
+++ b/api/spotbugs-gradle-plugin.api
@@ -52,6 +52,7 @@ public abstract interface class com/github/spotbugs/snom/SpotBugsExtension {
 	public abstract fun getRelease ()Lorg/gradle/api/provider/Property;
 	public abstract fun getReportLevel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getReportsDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getRunOnCheck ()Lorg/gradle/api/provider/Property;
 	public abstract fun getShowProgress ()Lorg/gradle/api/provider/Property;
 	public abstract fun getShowStackTraces ()Lorg/gradle/api/provider/Property;
 	public abstract fun getToolVersion ()Lorg/gradle/api/provider/Property;

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -245,4 +245,54 @@ dependencies {
         result.task(":spotbugsMain").outcome == SUCCESS
         result.output.contains("com.github.spotbugs:spotbugs-annotations:4.0.2")
     }
+
+    def "default behaviour runs spotbugs tasks as part of check"() {
+        setup:
+        buildFile << """
+spotbugs {
+}
+"""
+
+        when:
+        BuildResult result = gradleRunner
+                .withArguments('--debug', ":check")
+                .build()
+
+        then:
+        result.task(":spotbugsMain").outcome == SUCCESS
+    }
+
+    def "can set runOnCheck to false to disable automatic check dependency"() {
+        setup:
+        buildFile << """
+spotbugs {
+    runOnCheck = false
+}
+"""
+
+        when:
+        BuildResult result = gradleRunner
+                .withArguments('--debug', ":check")
+                .build()
+
+        then:
+        result.task(":spotbugsMain") == null
+    }
+
+    def "can still run spotbugs tasks without automatic check dependency"() {
+        setup:
+        buildFile << """
+spotbugs {
+    runOnCheck = false
+}
+"""
+
+        when:
+        BuildResult result = gradleRunner
+                .withArguments('--debug', ":spotbugsMain")
+                .build()
+
+        then:
+        result.task(":spotbugsMain").outcome == SUCCESS
+    }
 }

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsBasePlugin.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsBasePlugin.kt
@@ -56,6 +56,7 @@ class SpotBugsBasePlugin : Plugin<Project> {
             )
             useAuxclasspathFile.convention(true)
             useJavaToolchains.convention(true)
+            runOnCheck.convention(true)
         }
     }
 

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsExtension.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsExtension.kt
@@ -43,6 +43,7 @@ import org.gradle.api.provider.Property
  *     maxHeapSize = "1g"
  *     extraArgs = listOf("-nested:false")
  *     jvmArgs = listOf("-Duser.language=ja")
+ *     runOnCheck = true
  * }
  * ```
  *
@@ -152,4 +153,10 @@ interface SpotBugsExtension {
     val useAuxclasspathFile: Property<Boolean>
 
     val useJavaToolchains: Property<Boolean>
+
+    /**
+     * Property to specify if the SpotBugs tasks should automatically be marked as dependencies of the
+     * check task. Defaults to true.
+     */
+    val runOnCheck: Property<Boolean>
 }

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsPlugin.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsPlugin.kt
@@ -29,7 +29,10 @@ class SpotBugsPlugin : Plugin<Project> {
                 "The javaBase plugin has been applied, so making the check task depending on all of SpotBugsTask",
             )
             project.tasks.named(JavaBasePlugin.CHECK_TASK_NAME).configure {
-                it.dependsOn(project.tasks.withType(SpotBugsTask::class.java))
+                val runOnCheck = project.extensions.getByType(SpotBugsExtension::class.java).runOnCheck
+                if (runOnCheck.get()) {
+                    it.dependsOn(project.tasks.withType(SpotBugsTask::class.java))
+                }
             }
         }
         createTasks(project)


### PR DESCRIPTION
The new runOnCheck extension property (defaults to true) can be set to false, which disables the dependency from the `check` task to the spotbugs tasks. This is useful in cases where consumers do not want it to run automatically as part of `gradle check` but will run it in a separate context.

Fixes #1303