### PR TITLE
fix: pluginJarFiles.from() can accept a Configuration directly.

### DIFF
--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
@@ -294,7 +294,7 @@ abstract class SpotBugsTask : DefaultTask(), VerificationTask {
     @get:Classpath
     abstract val pluginJarFiles: ConfigurableFileCollection
 
-    @get:Internal
+    @get:Classpath
     abstract val spotbugsClasspath: ConfigurableFileCollection
 
     @get:Nested
@@ -374,14 +374,9 @@ abstract class SpotBugsTask : DefaultTask(), VerificationTask {
 
         val pluginConfiguration = project.configurations.named(SpotBugsPlugin.PLUGINS_CONFIG_NAME)
         pluginJarFiles.from(pluginConfiguration)
-        val configuration = project.configurations.getByName(SpotBugsPlugin.CONFIG_NAME)
-        val spotbugsSlf4j = project.configurations.getByName(SpotBugsPlugin.SLF4J_CONFIG_NAME)
-        spotbugsClasspath.from(
-            project.layout.files(
-                project.provider { spotbugsSlf4j.files },
-                project.provider { configuration.files },
-            ),
-        )
+        val configuration = project.configurations.named(SpotBugsPlugin.CONFIG_NAME)
+        val spotbugsSlf4j = project.configurations.named(SpotBugsPlugin.SLF4J_CONFIG_NAME)
+        spotbugsClasspath.from(configuration, spotbugsSlf4j)
     }
 
     /**

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
@@ -291,7 +291,7 @@ abstract class SpotBugsTask : DefaultTask(), VerificationTask {
 
     private var enableWorkerApi: Boolean = true
 
-    @get:Internal
+    @get:Classpath
     abstract val pluginJarFiles: ConfigurableFileCollection
 
     @get:Internal
@@ -372,10 +372,8 @@ abstract class SpotBugsTask : DefaultTask(), VerificationTask {
 
         analyseClassFile.set(project.layout.buildDirectory.file("$name-analyse-class-file.txt"))
 
-        val pluginConfiguration = project.configurations.getByName(SpotBugsPlugin.PLUGINS_CONFIG_NAME)
-        pluginJarFiles.from(
-            project.provider { pluginConfiguration.files },
-        )
+        val pluginConfiguration = project.configurations.named(SpotBugsPlugin.PLUGINS_CONFIG_NAME)
+        pluginJarFiles.from(pluginConfiguration)
         val configuration = project.configurations.getByName(SpotBugsPlugin.CONFIG_NAME)
         val spotbugsSlf4j = project.configurations.getByName(SpotBugsPlugin.SLF4J_CONFIG_NAME)
         spotbugsClasspath.from(


### PR DESCRIPTION
This fixes a bug where local project spotbugs plugins aren't being built when running `spotbugsMain`. Here's our project structure:
```kotlin
// module/build.gradle.kts
plugins {
  ... java, kotlin, etc...
  id("com.github.spotbugs") version "6.1.1"
}

dependencies {
  ... etc...
  spotbugsPlugin(project(":my-spotbugs-plugin))
}
```
```kotlin
// my-spotbugs-plugin/build.gradle.kts
plugins {
  ... java, kotlin, etc...
}

dependencies {
  implementation("com.github.spotbugs:spotbugs:4.9.0")
  implementation("com.github.spotbugs:spotbugs-annotations:4.9.0")
}
```
And then when I run `./gradlew module:spotbugsMain`, the task _succeeds_, despite violating the rule defined in `my-spotbugs-plugin`. If, however, I add this, then the task fails as expected:
```kotlin
// module/build.gradle.kts
tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
  dependsOn(":my-spotbugs-plugin:jar")
}
```
which led me to this PR (because that should not be necessary). There were two issues, both of which I had to fix to resolve this issue. First, this idiom is unnecessary and seems to just not work:
```kotlin
val pluginConfiguration = project.configurations.getByName(SpotBugsPlugin.PLUGINS_CONFIG_NAME)
pluginJarFiles.from(
    project.provider { pluginConfiguration.files },
)
```
that can be simplified to
```kotlin
val pluginConfiguration = project.configurations.named(SpotBugsPlugin.PLUGINS_CONFIG_NAME)
pluginJarFiles.from(pluginConfiguration)
```
Note also that I've changed `configurations.getByName()` to `configurations.named()` to maintain laziness (the latter returns a `Provider`).

Second, I changed the task input annotation from `@Internal` to `@Classpath`. This input is not, in my opinion, internal at all, but an important part of the task input. It also just doesn't work when annotated as an internal property. I suspect some other properties are also improperly marked as internal, but I haven't attempted to confirm this.