### PR TITLE
chore: exclude kotlin-stdlib from plugin dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Omit automatic compile dependency on kotlin-stdlib.
+# https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false
+
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4g
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library

```diff
diff --color=auto -r before/spotbugs-gradle-plugin-unspecified.module after/spotbugs-gradle-plugin-unspecified.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.0.21"
<           }
<         }
<       ],
60,68d50
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.0.21"
<           }
<         }
<       ],
diff --color=auto -r before/spotbugs-gradle-plugin-unspecified.pom after/spotbugs-gradle-plugin-unspecified.pom
23,30d22
<   <dependencies>
<     <dependency>
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.0.21</version>
<       <scope>compile</scope>
<     </dependency>
<   </dependencies>
```