### PR TITLE
core(build): Remove gradle cache as not allowed when setup gradle used

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          cache: gradle
           distribution: 'temurin'
           java-version-file: .java-version
       - name: Setup Gradle

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          cache: gradle
           distribution: 'temurin'
           java-version-file: .java-version
       - name: Set up Node.js

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        cache: gradle
         distribution: 'temurin'
         java-version-file: .java-version
     - name: Set up Node.js


### PR DESCRIPTION
setup gradle has its own cache, no need for this.