### PR TITLE
feat: add support for SpotBugs' chooseVisitors parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ spotbugs {
     reportLevel = Confidence.DEFAULT
     visitors = listOf("FindSqlInjection", "SwitchFallthrough")
     omitVisitors = listOf("FindNonShortCircuit")
+    chooseVisitors = listOf("-FindNonShortCircuit", "+TestASM")
     reportsDir = file("$buildDir/spotbugs")
     includeFilter = file("include.xml")
     excludeFilter = file("exclude.xml")
@@ -70,6 +71,7 @@ spotbugs {
 
     visitors = [ 'FindSqlInjection', 'SwitchFallthrough' ]
     omitVisitors = [ 'FindNonShortCircuit' ]
+    chooseVisitors = [ '-FindNonShortCircuit', '+TestASM' ]
     reportsDir = file("$buildDir/spotbugs")
     includeFilter = file("include.xml")
     excludeFilter = file("exclude.xml")

--- a/api/spotbugs-gradle-plugin.api
+++ b/api/spotbugs-gradle-plugin.api
@@ -39,6 +39,7 @@ public final class com/github/spotbugs/snom/SpotBugsBasePlugin$Companion {
 
 public abstract interface class com/github/spotbugs/snom/SpotBugsExtension {
 	public abstract fun getBaselineFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getChooseVisitors ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getEffort ()Lorg/gradle/api/provider/Property;
 	public abstract fun getExcludeFilter ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getExtraArgs ()Lorg/gradle/api/provider/ListProperty;
@@ -105,6 +106,7 @@ public abstract class com/github/spotbugs/snom/SpotBugsTask : org/gradle/api/Def
 	public abstract fun getAuxclasspathFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun getBaseName ()Ljava/lang/String;
 	public abstract fun getBaselineFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getChooseVisitors ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getClassDirs ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getClasses ()Lorg/gradle/api/file/FileCollection;
 	public abstract fun getEffort ()Lorg/gradle/api/provider/Property;

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ExtensionFunctionalTest.groovy
@@ -141,6 +141,21 @@ spotbugs {
         result.getOutput().contains("-omitVisitors, FindSqlInjection,SwitchFallthrough,")
     }
 
+    def "can use chooseVisitors"() {
+        buildFile << """
+spotbugs {
+    chooseVisitors = [ '-FindSqlInjection', '+TestASM' ]
+}"""
+        when:
+        def result = gradleRunner
+                .withArguments('--debug', 'spotbugsMain')
+                .build()
+
+        then:
+        SUCCESS == result.task(":spotbugsMain").outcome
+        result.getOutput().contains("-chooseVisitors, -FindSqlInjection,+TestASM,")
+    }
+
     def "can use onlyAnalyze"() {
         buildFile << """
 spotbugs {

--- a/src/functionalTest/groovy/com/github/spotbugs/snom/KotlinBuildScriptFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/KotlinBuildScriptFunctionalTest.groovy
@@ -65,6 +65,7 @@ spotbugs {
     reportLevel = "DEFAULT"
     visitors = listOf("FindSqlInjection", "SwitchFallthrough")
     omitVisitors = listOf("FindNonShortCircuit")
+    chooseVisitors = listOf("-FindNonShortCircuit", "+TestASM")
     reportsDir = file("\$buildDir/spotbugs")
     includeFilter = file("include.xml")
     excludeFilter = file("exclude.xml")

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsExtension.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsExtension.kt
@@ -35,6 +35,7 @@ import org.gradle.api.provider.Property
  *     reportLevel = com.github.spotbugs.snom.Confidence.DEFAULT
  *     visitors = listOf("FindSqlInjection", "SwitchFallthrough")
  *     omitVisitors = listOf("FindNonShortCircuit")
+ *     chooseVisitors = listOf("-FindNonShortCircuit", "+TestASM")
  *     reportsDir = file("$buildDir/spotbugs")
  *     includeFilter = file("include.xml")
  *     excludeFilter = file("exclude.xml")
@@ -79,6 +80,13 @@ interface SpotBugsExtension {
     val omitVisitors: ListProperty<String>
 
     /**
+     * Property to selectively enable/disable visitors (detectors) for analysis.
+     * Default is empty that means SpotBugs those visitors run which are enabled by default.
+     * This is a list with "+" or "-" before each detectors' name indicating enabling or disabling.
+     */
+    val chooseVisitors: ListProperty<String>
+
+    /**
      * Property to set the directory to generate report files. Default is `"$buildDir/reports/spotbugs"`.
      *
      * Note that each [SpotBugsTask] creates own subdirectory in this directory.
@@ -90,7 +98,7 @@ interface SpotBugsExtension {
      *
      * Note that this property will NOT limit which bug should be detected. To limit the target classes to analyze,
      * use [onlyAnalyze] instead.
-     * To limit the visitors (detectors) to run, use [visitors] and [omitVisitors] instead.
+     * To limit the visitors (detectors) to run, use [visitors], [omitVisitors] or [chooseVisitors] instead.
      *
      * See also [SpotBugs Manual about Filter file](https://spotbugs.readthedocs.io/en/stable/filter.html).
      */
@@ -101,7 +109,7 @@ interface SpotBugsExtension {
      *
      * Note that this property will NOT limit which bug should be detected. To limit the target classes to analyze,
      * use [onlyAnalyze] instead.
-     * To limit the visitors (detectors) to run, use [visitors] and [omitVisitors] instead.
+     * To limit the visitors (detectors) to run, use [visitors], [omitVisitors] or [chooseVisitors] instead.
      *
      * See also [SpotBugs Manual about Filter file](https://spotbugs.readthedocs.io/en/stable/filter.html).
      */

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory
  *     effort = 'default'
  *     visitors = [ 'FindSqlInjection', 'SwitchFallthrough' ]
  *     omitVisitors = [ 'FindNonShortCircuit' ]
+ *     chooseVisitors = [ '-FindNonShortCircuit', '+TestASM' ]
  *     reportsDir = file("$buildDir/reports/spotbugs")
  *     includeFilter = file('spotbugs-include.xml')
  *     excludeFilter = file('spotbugs-exclude.xml')
@@ -146,6 +147,14 @@ abstract class SpotBugsTask :
     abstract val omitVisitors: ListProperty<String>
 
     /**
+     * Property to selectively enable/disable visitors (detectors) for analysis.
+     * Default is empty that means SpotBugs those visitors run which are enabled by default.
+     * This is a list with "+" or "-" before each detectors' name indicating enabling or disabling.
+     */
+    @get:Input
+    abstract val chooseVisitors: ListProperty<String>
+
+    /**
      * Property to set the directory to generate report files. Default is `"$buildDir/reports/spotbugs/$taskName"}`.
      */
     @get:Internal("Refer the destination of each report instead.")
@@ -164,7 +173,7 @@ abstract class SpotBugsTask :
      *
      * Note that this property will NOT limit which bug should be detected. To limit the target classes to analyze,
      * use [onlyAnalyze] instead.
-     * To limit the visitors (detectors) to run, use [visitors] and [omitVisitors] instead.
+     * To limit the visitors (detectors) to run, use [visitors], [omitVisitors] or [chooseVisitors] instead.
      *
      * See also [SpotBugs Manual about Filter file](https://spotbugs.readthedocs.io/en/stable/filter.html).
      */
@@ -178,7 +187,7 @@ abstract class SpotBugsTask :
      *
      * Note that this property will NOT limit which bug should be detected. To limit the target classes to analyze,
      * use [onlyAnalyze] instead.
-     * To limit the visitors (detectors) to run, use [visitors] and [omitVisitors] instead.
+     * To limit the visitors (detectors) to run, use [visitors], [omitVisitors] or [chooseVisitors] instead.
      *
      * See also [SpotBugs Manual about Filter file](https://spotbugs.readthedocs.io/en/stable/filter.html).
      */
@@ -348,6 +357,7 @@ abstract class SpotBugsTask :
         effort.convention(extension.effort)
         visitors.convention(extension.visitors)
         omitVisitors.convention(extension.omitVisitors)
+        chooseVisitors.convention(extension.chooseVisitors)
         // the default reportsDir is "$buildDir/reports/spotbugs/"
         reportsDir.convention(extension.reportsDir)
         includeFilter.convention(extension.includeFilter)

--- a/src/main/kotlin/com/github/spotbugs/snom/internal/SpotBugsRunner.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/internal/SpotBugsRunner.kt
@@ -78,6 +78,10 @@ internal abstract class SpotBugsRunner {
             add("-omitVisitors")
             add(task.omitVisitors.get().joinToString(","))
         }
+        if (task.chooseVisitors.isPresent && task.chooseVisitors.get().isNotEmpty()) {
+            add("-chooseVisitors")
+            add(task.chooseVisitors.get().joinToString(","))
+        }
         if (task.includeFilter.isPresent) {
             add("-include")
             add(task.includeFilter.get().asFile.absolutePath)


### PR DESCRIPTION
This SpotBugs gradle plugin currently does not support SpotBugs' `chooseVisitors` parameter, which provides the possibility to enable and disable detectors. Without this it's not possible to run detectors disabled by default together with all enabled detectors without specifying all detectors. This PR resolves this problem.
The `chooseVisitors` parameter in the [SpotBugs official documentation](https://spotbugs.readthedocs.io/en/latest/running.html#detector-visitor-configuration-options).

Closes #690 

Pls lmk if I missed anything.