### PR TITLE
fix: #1513: Support lazy register API for reports

### DIFF
--- a/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
+++ b/src/functionalTest/groovy/com/github/spotbugs/snom/ReportFunctionalTest.groovy
@@ -473,4 +473,25 @@ spotbugsMain {
         Path reportDir = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs")
         !reportDir.resolve("main.xml").toFile().isFile()
     }
+
+    def "can lazily register report"() {
+        buildFile << """
+spotbugsMain {
+    reports {
+        register('xml') {
+            required = true
+        }
+    }
+}"""
+        when:
+        def result = gradleRunner
+                .withArguments('spotbugsMain')
+                .build()
+
+        then:
+        SUCCESS == result.task(":spotbugsMain").outcome
+
+        Path reportDir = rootDir.toPath().resolve("build").resolve("reports").resolve("spotbugs")
+        reportDir.resolve("main.xml").toFile().isFile()
+    }
 }

--- a/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
+++ b/src/main/kotlin/com/github/spotbugs/snom/SpotBugsTask.kt
@@ -410,6 +410,7 @@ abstract class SpotBugsTask :
     /**
      * Function defined to keep the backward compatibility with [org.gradle.api.reporting.Reporting] interface.
      */
+    @Suppress("unused")
     fun reports(
         configureAction: Action<NamedDomainObjectContainer<SpotBugsReport>>,
     ): NamedDomainObjectContainer<SpotBugsReport> {
@@ -433,5 +434,5 @@ abstract class SpotBugsTask :
     @Internal
     internal fun getRequiredReports(): Sequence<SpotBugsReport> = reports.matching {
         it.required.get()
-    }.asMap.values.asSequence()
+    }.asSequence()
 }


### PR DESCRIPTION
The problem was caused by using the eager (and in this instance, unnecessary) call to [`getAsMap()`](https://docs.gradle.org/current/javadoc/org/gradle/api/NamedDomainObjectCollection.html#getAsMap()) when retrieving required reports. 

Closes #1513.