### PR TITLE
fix: fix sonarqube deprecations

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Run SonarQube Scanner
       run: |
         if [ "$SONAR_LOGIN" != "" ]; then
-          ./gradlew sonarqube -Dsonar.login=$SONAR_LOGIN --no-daemon
+          ./gradlew sonar -Dsonar.token=$SONAR_LOGIN --no-daemon
         fi
       if: matrix.gradle == '8.14.3' && matrix.os == 'ubuntu-latest' && github.repository == 'spotbugs/spotbugs-gradle-plugin'
       env:

--- a/buildSrc/src/main/kotlin/com/github/spotbugs/com.github.spotbugs.test.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/github/spotbugs/com.github.spotbugs.test.gradle.kts
@@ -74,7 +74,7 @@ sonar {
 }
 
 tasks {
-    named("sonarqube") {
+    named("sonar") {
         mustRunAfter(jacocoTestReport)
     }
 }


### PR DESCRIPTION
In [the last successful build SonarQube Scanner run by CI](https://github.com/spotbugs/spotbugs-gradle-plugin/actions/runs/27453993844/job/81154841260) there are some deprecations:
```
> Task :sonarqube
Task 'sonarqube' is deprecated. Use 'sonar' instead.

The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.
```

On the next commit the sonarqube task in the [CI fails](https://github.com/spotbugs/spotbugs-gradle-plugin/actions/runs/27639048624/job/81733891603) with the following error:
```
> Task :sonarqube
Task 'sonarqube' is deprecated. Use 'sonar' instead.

Error retrieving feature flags, using default analyzer behavior
Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable, the 'sonar.projectKey' and 'sonar.organization' properties, or contact the project administrator to verify the token's permissions.

Failed to check if project 'com.github.spotbugs.gradle' is bound
Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable, the 'sonar.projectKey' and 'sonar.organization' properties, or contact the project administrator to verify the token's permissions.

> Task :sonarqube FAILED
```

This PR intends to fix these issues.